### PR TITLE
Proposed fix for mark baker incompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "markbaker-fix-namespace": "find ./vendor -name \"*.php\" | LC_ALL=C xargs -n 1 sed -e 's/(use|namespace) (Complex|Matrix)/\\1 GFExcel\\\\Vendor\\\\\\2/g' -E -i \"\"",
-        "markbaker-fix-autoload": "find ./vendor/composer -name \"*.php\" | LC_ALL=C xargs -n 1 sed -e 's/(Matrix|Complex)\\\\\/GFExcel\\\\\\\\Vendor\\\\\\\\\\1\\\\/g' -E -i \"\"",
+        "markbaker-fix-namespace": "find ./vendor -name \"*.php\" | xargs -n 1 sed -i -E -e 's/(use|namespace) (Complex|Matrix)/\\1 GFExcel\\\\Vendor\\\\\\2/g'",
+        "markbaker-fix-autoload": "find ./vendor/composer -name \"*.php\" | xargs -n 1 sed -i -E -e 's/(Matrix|Complex)\\\\\/GFExcel\\\\\\\\Vendor\\\\\\\\\\1\\\\/g'",
         "post-install-cmd": "composer run markbaker-fix-namespace",
         "post-update-cmd": "composer run markbaker-fix-namespace",
         "post-autoload-dump": "composer run markbaker-fix-autoload"

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,11 @@
         "phpstan/phpstan-mockery": "^0.12.5"
     },
     "scripts": {
-        "test" : "vendor/bin/phpunit"
+        "test": "vendor/bin/phpunit",
+        "markbaker-fix-namespace": "find ./vendor -name \"*.php\" | LC_ALL=C xargs -n 1 sed -e 's/(use|namespace) (Complex|Matrix)/\\1 GFExcel\\\\Vendor\\\\\\2/g' -E -i \"\"",
+        "markbaker-fix-autoload": "find ./vendor/composer -name \"*.php\" | LC_ALL=C xargs -n 1 sed -e 's/(Matrix|Complex)\\\\\/GFExcel\\\\\\\\Vendor\\\\\\\\\\1\\\\/g' -E -i \"\"",
+        "post-install-cmd": "composer run markbaker-fix-namespace",
+        "post-update-cmd": "composer run markbaker-fix-namespace",
+        "post-autoload-dump": "composer run markbaker-fix-autoload"
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,7 @@ Checkout this example:
 == Changelog ==
 = Unreleased
 * Bugfix: Default combiner glue for List Fields was accidentally changed.
+* Bugfix: Mark baker dependencies no longer clash with other plugins using the same dependencies.
 
 = 1.8.9
 * Conflict: Updated dependencies to resolve conflict with Visualizer.


### PR DESCRIPTION
Currently there are a few plugins that are incompatible with GFExcel, because all of them have the markbaker dependencies, in different versions. Composer usually can run multiple files next to each other. But these packages have functions declared in a custom namespace, but have no check if they are already defined (this fix is pending with Mark Baker; but so far no joy.

So when both plugins run (in different versions) you run into a php "cannot redefine function..." error. 

To remedy this I propose renaming the namespace of these dependencies around the vendor folder, as we don't use it in the `src` folder. This way there won't be any collision, because the functions are in separate namespaces. 

Doing this via the `composer.json` `scripts` help with being able to forget about it :-)