### PR TITLE
Enhancement: Composer.json constraint fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "doekenorg/gf-entries-in-excel",
+    "name": "gfexcel/gf-entries-in-excel",
     "description": "Never waste time importing CSV's again.",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-only",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-json": "*",
         "php": "^7.1",
-        "phpoffice/phpspreadsheet": "~1.12.0",
+        "phpoffice/phpspreadsheet": "^1.12",
         "composer/installers": "~1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gfexcel/gf-entries-in-excel",
+    "name": "doekenorg/gf-entries-in-excel",
     "description": "Never waste time importing CSV's again.",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-only",

--- a/readme.txt
+++ b/readme.txt
@@ -208,12 +208,11 @@ Checkout this example:
 3. Or download it from the list via the bulk selector
 
 == Changelog ==
-= Unreleased =
-* Enhancement: composer.json constraints updated for bedrock users.
 
-= 1.9.0 on May 5, 2021 =
+= 1.9.0 on May 6, 2021 =
 * Enhancement: Updated PHPSpreadsheet to 1.15.
 * Enhancement: Added `gfexcel_file_extension` webhook to overwrite the extension (by default, `.xlsx`).
+* Enhancement: composer.json constraints updated for Bedrock users.
 * Bugfix: Removed deprecation warning on Gravity Forms 2.5.
 * Bugfix: Sort order is now saved again on Gravity Forms 2.5.
 * Bugfix: Improve button appearance on Gravity Forms 2.5.

--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,8 @@ Checkout this example:
 3. Or download it from the list via the bulk selector
 
 == Changelog ==
+= Unreleased =
+* Enhancement: composer.json constraints updated for bedrock users.
 
 = 1.8.10 on April 13, 2021 =
 * Bugfix: Default combiner glue for List Fields was accidentally changed.


### PR DESCRIPTION
Should resolve #84

The big difference here is that a the constraint now allows for everything above version `1.12` of `phpoffice/phpspreadsheet`, whereas it before only allowed everything within the `1.12.*` range. 

Although this fixes the issues for bedrock users wanting to add `"roave/security-advisories": "dev-master"` it does mean that every new release for Wordpress (the one we add to the SVN) will have the latest version. This isn't a problem per se; but I always made sure to release at least a new minor version when that happened. 

Also, this update does not need to be released to the Wordpress SVN.  But it does need to be tagged as a new patch version for composer users (but I have another hotfix coming, so those can be released simultaneously). 

~~I also updated the package name too to `gfexcel/gf-entries-in-excel`. Once this enters the `master` branch, we can setup a new package on packagist under that name, and abandon `doekenorg/gf-entries-in-excel`.~~
We cannot do this now. Because this is a patch version it should be under `doekenorg/` first. Then we can abandon and start with `1.9.x` on the next release under `gfexcel/`