### PR TITLE
Quick fixes for GF 2.5 compatibility. 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,9 @@ Checkout this example:
 3. Or download it from the list via the bulk selector
 
 == Changelog ==
+= Unreleased =
+* Bugfix: Removed deprecation warning on Gravity Forms 2.5
+* Bugfix: Sort order is now saved again on Gravity Forms 2.5
 
 = 1.8.10 on April 13, 2021 =
 * Bugfix: Default combiner glue for List Fields was accidentally changed.

--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -12,6 +12,7 @@ use GFExcel\Renderer\PHPExcelRenderer;
 use GFExcel\Repository\FieldsRepository;
 use GFExcel\Repository\FormsRepository;
 use GFExcel\Shorttag\DownloadUrl;
+use Gravity_Forms\Gravity_Forms\Settings\Settings;
 
 class GFExcelAdmin extends \GFAddOn
 {
@@ -474,14 +475,18 @@ class GFExcelAdmin extends \GFAddOn
 
         echo "<br/>";
 
-        echo "<form method=\"post\">";
+        echo '<form method="post" id="gform-settings">';
         $this->securitySettings($form);
 
         $this->generalSettings($form);
 
         $this->sortableFields($form);
 
-        $this->settings_save(['value' => __('Save settings')], GFExcel::$slug);
+        if (class_exists(Settings::class)) {
+            echo (new Settings())->render_save_button();
+        } else {
+            $this->settings_save(['value' => __('Save settings')], GFExcel::$slug);
+        }
         echo "</form>";
     }
 

--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -13,7 +13,6 @@ use GFExcel\Repository\FieldsRepository;
 use GFExcel\Repository\FormsRepository;
 use GFExcel\Shorttag\DownloadUrl;
 use Gravity_Forms\Gravity_Forms\Settings\Fields\Base;
-use Gravity_Forms\Gravity_Forms\Settings\Settings;
 
 class GFExcelAdmin extends \GFAddOn
 {


### PR DESCRIPTION
Since 2.5 is now officially out I did a few quick tests. Currently the save button will trow a deprecation warning, and the sort-order is not being persisted anymore. This is because the fields are no longer arrays, but Field objects. These behave a bit different so we can't get the value the normal way. They also changed the prefix for fields from `_gform_addon` to `_gform_setting`, and the plugin had these hardcoded. 

This PR fixes those two issues. 