### PR TITLE
Hooks aren't applied on checkbox fields during export

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -208,6 +208,8 @@ Checkout this example:
 3. Or download it from the list via the bulk selector
 
 == Changelog ==
+= Unreleased =
+* Bugfix: Checkboxes didn't get all the hooks applied on export.
 
 = 1.8.13 on June 10, 2021 =
 * Bugfix: Plugin would not activate on hosts running PHP 7.1.

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -42,6 +42,13 @@ class CheckboxField extends BaseField implements RowsInterface
             if (!rgempty($index, $entry)) {
                 $value = $this->getFieldValue($entry, $index);
 
+                $value = gf_apply_filters([
+                    'gfexcel_field_value',
+                    $this->field->get_input_type(),
+                    $this->field->formId,
+                    $this->field->id
+                ], $value, $entry, $this->field);
+
                 yield $this->wrap([$value]);
             }
         }

--- a/src/Field/CheckboxField.php
+++ b/src/Field/CheckboxField.php
@@ -40,7 +40,7 @@ class CheckboxField extends BaseField implements RowsInterface
         foreach ($this->field->get_entry_inputs() as $input) {
             $index = (string) $input['id'];
             if (!rgempty($index, $entry)) {
-                $value = \GFCommon::selection_display(\rgar($entry, $index), $this->field, \rgar($entry, 'currency'));
+                $value = $this->getFieldValue($entry, $index);
 
                 yield $this->wrap([$value]);
             }


### PR DESCRIPTION
This PR is in response to [this ticket](https://wordpress.org/support/topic/add-support-for-the-survey-addon/). It turns out the checkbox values are not piped through the correct flow to apply all hooks. This prevents the survey add-on to upgrade the values from internal values to the textual output.  