### PR TITLE
Release 1.9.1

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.3', '7.4', '7.2']
     steps:
       - uses: actions/checkout@v2
       - name: Install PHP

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "ext-json": "*",
         "php": "^7.1",
         "gfexcel/base": "dev-master",
+        "phpoffice/phpspreadsheet": "1.12",
         "composer/installers": "~1.0",
         "frontpack/composer-assets-plugin": "^0.11.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "php": "^7.1",
+        "php": "^7.2",
         "gfexcel/base": "dev-master",
         "phpoffice/phpspreadsheet": "1.12",
         "composer/installers": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0fa47aebd57b99096d20706f026845b",
+    "content-hash": "b96af2510755f8e3991094da7ee57918",
     "packages": [
         {
             "name": "composer/installers",
@@ -212,17 +212,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/GFExcel/base.git",
-                "reference": "1534b922cf8ec4e5f02e3cef2a7b8d4e770198e5"
+                "reference": "8d1966b9e5c4c9071777de7140696163da317dc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GFExcel/base/zipball/1534b922cf8ec4e5f02e3cef2a7b8d4e770198e5",
-                "reference": "1534b922cf8ec4e5f02e3cef2a7b8d4e770198e5",
+                "url": "https://api.github.com/repos/GFExcel/base/zipball/8d1966b9e5c4c9071777de7140696163da317dc5",
+                "reference": "8d1966b9e5c4c9071777de7140696163da317dc5",
                 "shasum": ""
             },
             "require": {
-                "league/container": "^3.3",
-                "phpoffice/phpspreadsheet": "1.12"
+                "league/container": "^3.3"
             },
             "require-dev": {
                 "overtrue/phplint": "^2.3",
@@ -258,12 +257,12 @@
                     "email": "info@gfexcel.com"
                 }
             ],
-            "description": "Base for Gravity Forms Entries in Excel (Pro)",
+            "description": "Base for GravityExport",
             "support": {
                 "source": "https://github.com/GFExcel/base/tree/master",
                 "issues": "https://github.com/GFExcel/base/issues"
             },
-            "time": "2021-09-02T14:41:16+00:00"
+            "time": "2021-09-08T02:34:27+00:00"
         },
         {
             "name": "league/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b96af2510755f8e3991094da7ee57918",
+    "content-hash": "0bdb1a5d5d65ec9f5e228e91568926a1",
     "packages": [
         {
             "name": "composer/installers",
@@ -3897,7 +3897,7 @@
     "prefer-lowest": false,
     "platform": {
         "ext-json": "*",
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/gfexcel.php
+++ b/gfexcel.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     GravityExport Lite
- * Version:         1.9.0
+ * Version:         1.9.1
  * Plugin URI:      https://gfexcel.com
  * Description:     Export all Gravity Forms entries to Excel (.xlsx) or CSV via a secret shareable URL.
  * Author:          GravityView
@@ -29,7 +29,7 @@ if ( ! defined( 'GFEXCEL_PLUGIN_FILE' ) ) {
 }
 
 if ( ! defined( 'GFEXCEL_PLUGIN_VERSION' ) ) {
-	define( 'GFEXCEL_PLUGIN_VERSION', '1.9.0' );
+	define( 'GFEXCEL_PLUGIN_VERSION', '1.9.1' );
 }
 
 if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {

--- a/gfexcel.php
+++ b/gfexcel.php
@@ -32,6 +32,21 @@ if ( ! defined( 'GFEXCEL_PLUGIN_VERSION' ) ) {
 	define( 'GFEXCEL_PLUGIN_VERSION', '1.9.0' );
 }
 
+if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {
+	define( 'GFEXCEL_MIN_PHP_VERSION', '7.2' );
+}
+
+if ( version_compare( phpversion(), GFEXCEL_MIN_PHP_VERSION, '<' ) ) {
+	$show_minimum_php_version_message = function () {
+		$message = wpautop( sprintf( esc_html__( 'GravityExport Lite requires PHP %s or newer.', 'gf-entries-in-excel' ), GFEXCEL_MIN_PHP_VERSION ) );
+		echo "<div class='error'>$message</div>";
+	};
+
+	add_action( 'admin_notices', $show_minimum_php_version_message );
+
+	return;
+}
+
 add_action('gform_loaded', static function (): void {
     if (!class_exists('GFForms') || !method_exists('GFForms', 'include_addon_framework')) {
         return;

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Gravity Forms, GravityForms, Excel, Export, Download, Entries, CSV
 Requires at least: 4.0
 Requires PHP: 7.2
 Tested up to: 5.8
-Stable tag: 1.9.0
+Stable tag: 1.9.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -211,9 +211,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= develop =
+= 1.9.1 on September 8, 2021 =
 
 * **GravityExport Lite** requires PHP 7.2
+* Bugfix: Fatal error when trying to download an export file.
 
 = 1.9.0 on September 7, 2021 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: gravityview, doekenorg
 Donate link: https://gravityview.co/gravity-forms-entries-in-excel/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-donate
 Tags: Gravity Forms, GravityForms, Excel, Export, Download, Entries, CSV
 Requires at least: 4.0
-Requires PHP: 7.1
-Tested up to: 5.8.1
+Requires PHP: 7.2
+Tested up to: 5.8
 Stable tag: 1.9.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -34,7 +34,7 @@ Please visit [gfexcel.com](https://gfexcel.com?utm_source=plugin&utm_campaign=gr
 
 = Requirements =
 
-* PHP 7.1
+* PHP 7.2
 * `php-xml` and `php-zip` libraries. The plugin will check for those.
 * Gravity Forms 2.0 or higher
 
@@ -211,6 +211,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* **GravityExport Lite** requires PHP 7.2
+
 = 1.9.0 on September 7, 2021 =
 
 * **Gravity Forms Entries in Excel is now known as GravityExport Lite**
@@ -237,7 +241,7 @@ __Developer Updates:__
 * Bugfix: Plugin would not activate on hosts running PHP 7.1.
 
 = 1.8.12 on May 14, 2021 =
-* Enhancement: Updated PHPSpreadsheet to 1.17.
+* Enhancement: Updated PhpSpreadsheet to 1.17.
 * Enhancement: Added `gfexcel_file_extension` webhook to overwrite the extension (by default, `.xlsx`).
 * Enhancement: composer.json constraints updated for Bedrock users.
 * Bugfix: Removed deprecation warning on Gravity Forms 2.5.
@@ -293,7 +297,7 @@ Not released on WordPress due to linter issues.
 * Bugfix: 'gfexcel_renderer_csv_include_separator_line' had a typo.
 * Bugfix: List field threw notice when you changed the column names.
 * Bugfix: Disabled warning when `set_time_limit` is not allowed to prevent failing download.
-* Enhancement: Updated PHPSpreadsheet to 1.12 (last to support PHP 7.1).
+* Enhancement: Updated PhpSpreadsheet to 1.12 (last to support PHP 7.1).
 * Enhancement: Added quick-link to documentation on the plugins page.
 * Enhancement: Added quick-link to settings on the plugins page.
 * Enhancement: Replaced all translation calls with WordPress native calls to be polite to Poedit.
@@ -320,7 +324,7 @@ Not released on WordPress due to linter issues.
 * Bugfix: Column-names now match the filters in the sortable lists.
 * Bugfix: Filters now only respond to the correct URL.
 * Bugfix: Forgot to update composer.json to reflect minimum PHP version of 7.1. (for Bedrock users).
-* Changed: Updated composer.json to use phpspreadsheet ~1.9.0 to be consistent with the normal plugin version.
+* Changed: Updated composer.json to use PhpSpreadsheet ~1.9.0 to be consistent with the normal plugin version.
 
 = 1.7.0 =
 * Feature: Added field filtering to the URL. Checkout [the documentation](https://gfexcel.com/docs/filtering/) for more info.
@@ -334,7 +338,7 @@ Not released on WordPress due to linter issues.
 * Enhancement: Added a `gfexcel_download_renderer` hook to inject a custom renderer.
 * Bugfix: Prevent notice at render-time for `ob_end_clean`.
 * Bugfix: Reset download hash and counter on duplicated form.
-* Updated: PHPSpreadsheet updated to 1.9.0. Package to `^1.3`.
+* Updated: PhpSpreadsheet updated to 1.9.0. Package to `^1.3`.
 
 = 1.6.3 =
 * Bugfix: Radio and checkboxes caused unforeseen error on short tag for GF.

--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -288,7 +288,7 @@ class GFExcelAdmin extends \GFAddOn implements AddonInterface
 				        GFExcel::$slug
 			        ),
 			        '<strong><a href="https://wordpress.org/support/plugin/gf-entries-in-excel/reviews/?filter=5#new-post" target="_blank" title="' . esc_attr__( 'This link opens in a new window', GFExcel::$slug ) . '">',
-			        '</a></strong>', esc_html( $this->getUsageCount() ), esc_html( $this->getUsageTarget() ),
+			        '</a></strong>', esc_html( $this->getUsageCount() ), esc_html( $this->getUsageTarget() )
 		        );
 		        ?>
             </p>

--- a/src/GFExcelOutput.php
+++ b/src/GFExcelOutput.php
@@ -200,7 +200,13 @@ class GFExcelOutput
 	private function getFeed()
 	{
 		if ( ! $this->feed ) {
-			$this->feed = \GFAPI::get_feed( $this->feed_id );
+			$feed = \GFAPI::get_feed( $this->feed_id );
+
+			if ( is_wp_error( $feed ) ) {
+				$feed = [];
+			}
+
+			$this->feed = $feed;
 		}
 
 		return $this->feed;


### PR DESCRIPTION
* **GravityExport Lite** requires PHP 7.2
* Bugfix: Fatal error when trying to download an export file.