### PR TITLE
Release 1.9.2

### DIFF
--- a/gfexcel.php
+++ b/gfexcel.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     GravityExport Lite
- * Version:         1.9.1
+ * Version:         1.9.2
  * Plugin URI:      https://gfexcel.com
  * Description:     Export all Gravity Forms entries to Excel (.xlsx) or CSV via a secret shareable URL.
  * Author:          GravityView
@@ -29,7 +29,7 @@ if ( ! defined( 'GFEXCEL_PLUGIN_FILE' ) ) {
 }
 
 if ( ! defined( 'GFEXCEL_PLUGIN_VERSION' ) ) {
-	define( 'GFEXCEL_PLUGIN_VERSION', '1.9.1' );
+	define( 'GFEXCEL_PLUGIN_VERSION', '1.9.2' );
 }
 
 if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -13,30 +13,57 @@ Export all Gravity Forms entries to Excel (.xlsx) or CSV via a download button o
 
 == Description ==
 
+> ### GravityExport is the ultimate no-hassle solution for exporting data from Gravity Forms.
 > Powerful new functionality is available with GravityExport! Save exports to FTP & Dropbox, export as PDF, and format exports for data analysis.
 >
 > [Learn more about GravityExport](https://gravityview.co/extensions/gf-excel-pro/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-learn-more)
 
-Export Gravity Forms entries directly to Excel or CSV using a unique and secure URL. No need to login or create a
-user account for that one person who needs the results. Just copy the URL, and give it to the person who needs it.
-It's that simple!
+### Export entries using a secure URL
 
-**Why not export entries from Gravity Forms?**
+When you configure a new export, the plugin will generate a secure download URL that you can share with anyone who needs the data (No need to log in!). Reports will automatically update as new entries are added.
 
-Using Gravity Forms, you can export a CSV file and import it to Excel. But an admin always needs to be involved
-and using Excel to import a CSV is a pain.
+### Export directly to Excel (.xlsx)
+
+Export your entries directly to .xlsx format. No more wasting time importing your CSV files into Excel and reformatting columns.
+
+### Configure export fields
+
+Configure the fields to be included in Instead of configuring the export fields every time you export a CSV in Gravity Forms,
+
+### Gain powerful functionality
+
+The [full version of GravityExport](https://gravityview.co/extensions/gravityexport/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-full-version) unlocks these game-changing features:
+
+* 📄 **PDF Export**
+GravityExport supports exporting entries as PDF! You can choose to have a PDF generated for each entry or one PDF that includes all entries. You can also customize the PDF output by adjusting the size, orientation, and more.
+* 📦 **Dropbox integration**
+Save your form data directly to Dropbox.
+* 👩🏽‍💻 **Send reports to FTP**
+Store reports on your own FTP server! GravityExport supports the SFTP, FTP + SSL, and FTP protocols.
+* ⬇️ **Multiple download URLs**
+Create multiple export URLs that output to different formats and include different fields.
+* 📊 **Export data ready for analysis**
+Make it easier to process your Gravity Forms data by splitting fields with multiple values into different rows.
 
 We've written an article that contains all you need to know about [exporting data from Gravity Forms](https://gravityview.co/exporting-gravity-forms-to-excel/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-all-need-to-know).
 
-== Documentation ==
+### Documentation & support
 
-Please visit [gfexcel.com](https://gfexcel.com?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme) for the documentation site! You'll find available features, fields, and filters. If you are a developer; this site is probably for you.
+If you have any questions regarding GravityExport Lite, [check out our documentation](https://docs.gravityview.co/category/783-gravityexport?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-checkout-docs).
 
-= Requirements =
+If you need further assistance, [read this first](https://wordpress.org/support/topic/read-me-first-9/) and our support team will gladly give you a helping hand!
+
+#### Requirements
 
 * PHP 7.2
 * `php-xml` and `php-zip` libraries. The plugin will check for those.
 * Gravity Forms 2.0 or higher
+
+#### Credits
+
+- The GF Entries in Excel plugin was created by [Doeke Norg](https://doeken.org)
+- Logo by Karlo Norg | [SQUID Media](https://www.squidmedia.nl)
+- Banner Photo by [Matt Benson](https://unsplash.com/@mattgyver) on [Unsplash](https://unsplash.com/photos/rHbob_bEsSs)
 
 == Installation ==
 
@@ -480,9 +507,3 @@ This update also makes the slug more secure and unique by not using the (possibl
 
 = 1.0 =
 * First release
-
-== Credits ==
-
-- The GF Entries in Excel plugin was created by [Doeke Norg](https://doeken.org)
-- Logo by Karlo Norg | [SQUID Media](https://www.squidmedia.nl)
-- Banner Photo by [Matt Benson](https://unsplash.com/@mattgyver) on [Unsplash](https://unsplash.com/photos/rHbob_bEsSs)

--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,11 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Bugfix: Fatal error when using Gravity Forms ≤2.4.23.
+	- We highly recommend upgrading to Gravity Forms >2.5 .
+
 = 1.9.1 on September 8, 2021 =
 
 * **GravityExport Lite** requires PHP 7.2

--- a/readme.txt
+++ b/readme.txt
@@ -18,21 +18,51 @@ Export all Gravity Forms entries to Excel (.xlsx) or CSV via a download button o
 >
 > [Learn more about GravityExport](https://gravityview.co/extensions/gf-excel-pro/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-learn-more)
 
-[youtube https://youtu.be/diqNgFCguM4]
-
 ### Export entries using a secure URL
 
 When you configure a new export, the plugin will generate a secure download URL that you can share with anyone who needs the data (No need to log in!). Reports will automatically update as new entries are added.
 
+#### GravityExport Lite includes many features:
+
+- Limit access to downloads—either make a URL public or require users to be logged-in with correct permissions
+- Download reports from multiple forms at once
+- Export entry notes along with entries
+- Transpose data (instead of one entry per-row, it would be one column per row)
+- Attach entry exports to notifications
+
+[youtube https://youtu.be/diqNgFCguM4]
+
 ### Export directly to Excel (.xlsx)
 
-Export your entries directly to .xlsx format. No more wasting time importing your CSV files into Excel and reformatting columns.
+Export your entries directly to .xlsx format. No more wasting time importing your CSV files into Excel and re-configuring columns.
+
+### Export as CSV
+
+If you'd prefer to have your reports generated as CSV, GravityExport Lite makes it easy.
+
+### Add search filters to the URL
+
+Once you have your download URL, you can easily [filter by date range and field value](https://gfexcel.com/docs/filtering/).
 
 ### Configure export fields
 
-Configure the fields to be included in Instead of configuring the export fields every time you export a CSV in Gravity Forms,
+Save time generating exports in Gravity Forms: Configure the fields that are included in your CSV or Excel export. No need to set up every time!
 
-### Gain powerful functionality
+### Documentation & support
+
+If you have any questions regarding GravityExport Lite, [check out our documentation](https://docs.gravityview.co/category/783-gravityexport?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-checkout-docs).
+
+If you need further assistance, [read this first](https://wordpress.org/support/topic/read-me-first-9/) and our support team will gladly give you a helping hand!
+
+#### Requirements
+
+* PHP 7.2
+* `php-xml` and `php-zip` libraries. The plugin will check for those.
+* Gravity Forms 2.0 or higher
+
+<hr>
+
+### Gain additional powerful functionality
 
 The [full version of GravityExport](https://gravityview.co/extensions/gravityexport/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-full-version) unlocks these game-changing features:
 
@@ -48,18 +78,6 @@ Create multiple export URLs that output to different formats and include differe
 Make it easier to process your Gravity Forms data by splitting fields with multiple values into different rows.
 
 We've written an article that contains all you need to know about [exporting data from Gravity Forms](https://gravityview.co/exporting-gravity-forms-to-excel/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-all-need-to-know).
-
-### Documentation & support
-
-If you have any questions regarding GravityExport Lite, [check out our documentation](https://docs.gravityview.co/category/783-gravityexport?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-checkout-docs).
-
-If you need further assistance, [read this first](https://wordpress.org/support/topic/read-me-first-9/) and our support team will gladly give you a helping hand!
-
-#### Requirements
-
-* PHP 7.2
-* `php-xml` and `php-zip` libraries. The plugin will check for those.
-* Gravity Forms 2.0 or higher
 
 #### Credits
 

--- a/readme.txt
+++ b/readme.txt
@@ -18,6 +18,8 @@ Export all Gravity Forms entries to Excel (.xlsx) or CSV via a download button o
 >
 > [Learn more about GravityExport](https://gravityview.co/extensions/gf-excel-pro/?utm_source=plugin&utm_campaign=gravityexport-lite&utm_content=readme-learn-more)
 
+[youtube https://youtu.be/diqNgFCguM4]
+
 ### Export entries using a secure URL
 
 When you configure a new export, the plugin will generate a secure download URL that you can share with anyone who needs the data (No need to log in!). Reports will automatically update as new entries are added.

--- a/readme.txt
+++ b/readme.txt
@@ -261,7 +261,7 @@ You can hide a row by adding a hook. Checkout this example:
 = 1.9.2 on September 13, 2021 =
 
 * Bugfix: Fatal error when using Gravity Forms ≤2.4.23.
-	- We highly recommend upgrading to Gravity Forms >2.5 .
+	- We highly recommend upgrading to Gravity Forms >2.5.
 
 = 1.9.1 on September 8, 2021 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Gravity Forms, GravityForms, Excel, Export, Download, Entries, CSV
 Requires at least: 4.0
 Requires PHP: 7.2
 Tested up to: 5.8
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -258,7 +258,7 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= develop =
+= 1.9.2 on September 13, 2021 =
 
 * Bugfix: Fatal error when using Gravity Forms ≤2.4.23.
 	- We highly recommend upgrading to Gravity Forms >2.5 .

--- a/src/GFExcelOutput.php
+++ b/src/GFExcelOutput.php
@@ -200,13 +200,10 @@ class GFExcelOutput
 	private function getFeed()
 	{
 		if ( ! $this->feed ) {
-			$feed = \GFAPI::get_feed( $this->feed_id );
+			// TODO: Use \GFAPI::get_feed when GF minimum version requirement is bumped to ≥2.4.24
+			$feeds = \GFAPI::get_feeds( $this->feed_id, null, null, null );
 
-			if ( is_wp_error( $feed ) ) {
-				$feed = [];
-			}
-
-			$this->feed = $feed;
+			$this->feed = ! is_wp_error( $feeds ) ? $feeds[0] : [];
 		}
 
 		return $this->feed;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,6 @@ if (!defined('GFEXCEL_PLUGIN_FILE')) {
     define('GFEXCEL_PLUGIN_FILE', dirname(__FILE__, 2) . '/gfexcel.php');
 }
 if (!defined('GFEXCEL_PLUGIN_VERSION')) {
-	define('GFEXCEL_PLUGIN_VERSION', '1.9.0');
+	define('GFEXCEL_PLUGIN_VERSION', '1.9.2');
 }
 WP_Mock::bootstrap();


### PR DESCRIPTION
* Bugfix: Fatal error when using Gravity Forms ≤2.4.23.
	- We highly recommend upgrading to Gravity Forms >2.5.