### PR TITLE
Addded gform_ filters for csv delimiter and BOM.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,11 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Enhancement: `gform_export_separator` filter will also be used to determine the delimiter.
+* Enhancement: `gform_include_bom_export_entries` filter will also be used to determine BOM character use.
+
 = 1.9.3 on September 30, 2021 =
 
 * Bugfix: Feed settings page would break when using Gravity Forms ≥2.5.10.1.

--- a/src/Renderer/AbstractPHPExcelRenderer.php
+++ b/src/Renderer/AbstractPHPExcelRenderer.php
@@ -445,7 +445,8 @@ abstract class AbstractPHPExcelRenderer extends AbstractRenderer
     private function setCsvProperties(Csv $objWriter): void
     {
         // updates the delimiter
-        $objWriter->setDelimiter((string) apply_filters('gfexcel_renderer_csv_delimiter', $objWriter->getDelimiter()));
+	    $delimiter = apply_filters( 'gform_export_separator', $objWriter->getDelimiter() );
+	    $objWriter->setDelimiter( (string) apply_filters( 'gfexcel_renderer_csv_delimiter', $delimiter ) );
 
         // updates the enclosure
         $objWriter->setEnclosure((string) apply_filters('gfexcel_renderer_csv_enclosure', $objWriter->getEnclosure()));
@@ -457,7 +458,8 @@ abstract class AbstractPHPExcelRenderer extends AbstractRenderer
         ));
 
         // whether to use a BOM
-        $objWriter->setUseBOM((bool) apply_filters('gfexcel_renderer_csv_use_bom', $objWriter->getUseBOM()));
+	    $use_bom = apply_filters( 'gform_include_bom_export_entries', $objWriter->getUseBOM() );
+	    $objWriter->setUseBOM( (bool) apply_filters( 'gfexcel_renderer_csv_use_bom', $use_bom ) );
 
         // whether to include a separator line
         $objWriter->setIncludeSeparatorLine((bool) apply_filters(


### PR DESCRIPTION
- Added `gform_include_bom_export_entries` before `gfexcel_renderer_csv_use_bom`. 
- Added `gform_export_separator` before `gfexcel_renderer_csv_delimiter`.

Resolves #103