### PR TITLE
File upload default value.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Bugfix: Default value of file upload was not available without saving the general settings once.
+
 = 1.9.3 on September 30, 2021 =
 
 * Bugfix: Feed settings page would break when using Gravity Forms ≥2.5.10.1.

--- a/src/Field/FileUploadField.php
+++ b/src/Field/FileUploadField.php
@@ -44,9 +44,14 @@ class FileUploadField extends BaseField
 	 * @return bool Whether the uploads should be shown as a column.
 	 */
 	private function showFileUploadsAsColumn() {
+
+		// The default value of `true` will not be returned by get_plugin_setting(); it will return null by default.
+		// So we apply the ?? operator and return true as the default value.
+		$fileuploads_enabled = GFExcelAdmin::get_instance()->get_plugin_setting( 'fileuploads_enabled' ) ?? true;
+
 		return gf_apply_filters( [
 			'gfexcel_field_fileuploads_enabled',
 			$this->field->formId,
-		], (bool) ( GFExcelAdmin::get_instance()->get_plugin_setting( 'fileuploads_enabled' ) ?? true ) );
+		], (bool) $fileuploads_enabled );
 	}
 }

--- a/src/Field/FileUploadField.php
+++ b/src/Field/FileUploadField.php
@@ -36,15 +36,17 @@ class FileUploadField extends BaseField
         return parent::getColumns();
     }
 
-    /**
-     * Wether the uploads should be shown as a column
-     * @return bool
-     */
-    private function showFileUploadsAsColumn()
-    {
-        return gf_apply_filters([
-            'gfexcel_field_fileuploads_enabled',
-            $this->field->formId
-        ], !!GFExcelAdmin::get_instance()->get_plugin_setting('fileuploads_enabled'));
-    }
+	/**
+	 * Whether the uploads should be shown as a column.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool Whether the uploads should be shown as a column.
+	 */
+	private function showFileUploadsAsColumn() {
+		return gf_apply_filters( [
+			'gfexcel_field_fileuploads_enabled',
+			$this->field->formId,
+		], (bool) ( GFExcelAdmin::get_instance()->get_plugin_setting( 'fileuploads_enabled' ) ?? true ) );
+	}
 }

--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -1253,7 +1253,7 @@ class GFExcelAdmin extends \GFAddOn implements AddonInterface
     {
         if (array_key_exists(GFExcel::KEY_ENABLED_NOTES, $form)) {
             return (int) $form[GFExcel::KEY_ENABLED_NOTES];
-        };
+        }
 
         return $this->get_plugin_setting('notes_enabled');
     }


### PR DESCRIPTION
MR Resolves #104

The default value of `true` will not be returned by `get_plugin_setting()`. This will return `null` by default. So we apply the `??` operator and return `true` as the default value.