### PR TITLE
Added native support for nested forms.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Enhancement: Support for Gravity Perks Nested Forms.
+
 = 1.9.3 on September 30, 2021 =
 
 * Bugfix: Feed settings page would break when using Gravity Forms ≥2.5.10.1.

--- a/src/Field/NestedFormField.php
+++ b/src/Field/NestedFormField.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace GFExcel\Field;
+
+/**
+ * A field transformer for {@see \GP_Nested_Form_Field}.
+ * @since $ver$
+ */
+class NestedFormField extends SeparableField implements RowsInterface {
+	/**
+	 * @inheritdoc
+	 * @since $ver$
+	 */
+	public function getRows( ?array $entry = null ): iterable {
+		if ( ! class_exists( 'GP_Nested_Forms' ) ) {
+			yield [];
+		} else {
+			$value = $entry[ $this->field->id ] ?? null;
+			$keys  = array_flip( $this->field->gpnfFields ?? [] );
+
+			// Map all entries to filter out the unwanted values.
+			yield from array_map( function ( array $entry ) use ( $keys ): array {
+				// Retrieve only the fields that are set on the form field.
+				return $this->wrap( array_values( array_intersect_key( $entry, $keys ) ) );
+			}, \GP_Nested_Forms::get_instance()->get_entries( $value ) );
+		}
+	}
+
+	/**
+	 * @inheritdoc
+	 *
+	 * Overwritten to retrieve the columns from the nested form.
+	 *
+	 * @since $ver$
+	 */
+	protected function getSeparatedColumns(): array {
+		if ( ! class_exists( 'GP_Nested_Forms' ) || ! $nested_form = \GFAPI::get_form( $this->field->gpnfForm ) ) {
+			return [];
+		}
+
+		$fields = array_filter( $nested_form['fields'], function ( \GF_Field $field ) {
+			return in_array( $field->id, $this->field->gpnfFields ?? [], false );
+		} );
+
+		return array_map( function ( \GF_Field $field ) {
+			return gf_apply_filters( [
+				'gfexcel_field_label',
+				$field->get_input_type(),
+				$field->formId,
+				$field->id,
+			], sprintf(
+				'%s (%s)', // Nested field label (Wrapper label)
+				$this->getSubLabel( $field ),
+				$this->getSubLabel( $this->field )
+			), $field );
+		}, $fields );
+	}
+}

--- a/src/Field/SeparableField.php
+++ b/src/Field/SeparableField.php
@@ -5,6 +5,10 @@ namespace GFExcel\Field;
 use GFExcel\GFExcelAdmin;
 use GFExcel\Values\BaseValue;
 
+/**
+ * A field transformer that serves as the base for every field that has sub fields.
+ * @since 1.6.0
+ */
 class SeparableField extends BaseField
 {
     /** @var string */
@@ -112,13 +116,13 @@ class SeparableField extends BaseField
     protected function getVisibleSubfields()
     {
         return array_filter((array) $this->field->get_entry_inputs(), function ($subfield) {
-            return isset($subfield['isHidden']) ? !$subfield['isHidden'] : true;
+            return ! isset( $subfield['isHidden'] ) || ! $subfield['isHidden'];
         });
     }
 
     /**
      * Get the label for a subfield.
-     * @param mixed[] $field The field object.
+     * @param array|\ArrayAccess $field The field object.
      * @return string The sub label.
      */
     protected function getSubLabel($field)

--- a/src/Transformer/Transformer.php
+++ b/src/Transformer/Transformer.php
@@ -22,7 +22,7 @@ class Transformer
         'checkbox' => 'GFExcel\Field\CheckboxField',
         'date' => 'GFExcel\Field\DateField',
         'fileupload' => 'GFExcel\Field\FileUploadField',
-	    'form' => 'GFExcel\Field\NestedFormField',
+        'form' => 'GFExcel\Field\NestedFormField',
         'list' => 'GFExcel\Field\ListField',
         'meta' => 'GFExcel\Field\MetaField',
         'name' => 'GFExcel\Field\SeparableField',

--- a/src/Transformer/Transformer.php
+++ b/src/Transformer/Transformer.php
@@ -22,6 +22,7 @@ class Transformer
         'checkbox' => 'GFExcel\Field\CheckboxField',
         'date' => 'GFExcel\Field\DateField',
         'fileupload' => 'GFExcel\Field\FileUploadField',
+	    'form' => 'GFExcel\Field\NestedFormField',
         'list' => 'GFExcel\Field\ListField',
         'meta' => 'GFExcel\Field\MetaField',
         'name' => 'GFExcel\Field\SeparableField',


### PR DESCRIPTION
This MR add's a new Transformer field for the `form` field type; which is a GP Nested Forms field. 

This field will return columns for the selected nested fields.
The column label will be the nested field label, suffixed by the field label. This can be overwritten via the `gfexcel_field_label` hook.

The result for the Lite edition will be concatenated like any other separable field. And on the pro version each entry will have its own row; if one chooses to do so for separable fields.


*Note* There is no support for exporting these values to a different sheet. I figured that could be a separate feature.

This MR will resolve #98 