### PR TITLE
Fixed export separator issue + added form id to hooks.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased
+* Bugfix: Possible errors when using `gform_export_separator` callbacks with 2 expected parameters.
+* Enhancement: Updated all `gfexcel_renderer_csv_*` hooks to include the form id.
+
 = 1.10.1 on December 10, 2021 =
 
 * Bufgix: Fatal error when using the plugin with PHP <7.4.

--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -729,7 +729,7 @@ class GFExcelAdmin extends \GFAddOn implements AddonInterface
 
         // get_posted_settings() doesn't capture all the settings added using the `gfexcel_general_settings` filter,
         // so we add the values back in here.
-        return array_merge($settings, array_reduce(array_keys($form), function ($settings, $key) use ($form, $extra_settings) {
+        return array_merge($settings, array_reduce(array_keys($form), function ($settings, $key) use ($form) {
 
             if ( stripos($key, 'gfexcel_') === 0 || stripos($key, 'gravityexport') === 0 ) {
                 $settings[$key] = $form[$key];

--- a/src/Renderer/AbstractPHPExcelRenderer.php
+++ b/src/Renderer/AbstractPHPExcelRenderer.php
@@ -21,7 +21,7 @@ use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 /**
  * The base for a {@see PhpSpreadsheet} renderer.
  */
-abstract class AbstractPHPExcelRenderer extends AbstractRenderer
+abstract class AbstractPHPExcelRenderer extends AbstractRenderer implements RendererInterface
 {
     /** @var Spreadsheet */
     protected $spreadsheet;
@@ -32,6 +32,13 @@ abstract class AbstractPHPExcelRenderer extends AbstractRenderer
      * @var IWriter[]
      */
     protected $writer = [];
+
+	/**
+	 * The current form object.
+	 * @since $ver$
+	 * @var array
+	 */
+    protected $form = [];
 
     /**
      * Creates an AbstractPHPExcelRenderer instance.
@@ -442,29 +449,44 @@ abstract class AbstractPHPExcelRenderer extends AbstractRenderer
      * @since 1.7.5
      * @param Csv $objWriter The object writer.
      */
-    private function setCsvProperties(Csv $objWriter): void
-    {
-        // updates the delimiter
-	    $delimiter = apply_filters( 'gform_export_separator', $objWriter->getDelimiter() );
-	    $objWriter->setDelimiter( (string) apply_filters( 'gfexcel_renderer_csv_delimiter', $delimiter ) );
+	private function setCsvProperties( Csv $objWriter ): void {
+		// updates the delimiter
+		$form_id   = $this->form['id'] ?? 0;
+		$delimiter = gf_apply_filters( [ 'gform_export_separator', $form_id ], $objWriter->getDelimiter(), $form_id );
 
-        // updates the enclosure
-        $objWriter->setEnclosure((string) apply_filters('gfexcel_renderer_csv_enclosure', $objWriter->getEnclosure()));
+		$objWriter->setDelimiter( (string) gf_apply_filters(
+			[ 'gfexcel_renderer_csv_delimiter', $form_id ],
+			$delimiter,
+			$form_id
+		) );
 
-        // updates the line ending
-        $objWriter->setLineEnding((string) apply_filters(
-            'gfexcel_renderer_csv_line_ending',
-            $objWriter->getLineEnding()
-        ));
+		// updates the enclosure
+		$objWriter->setEnclosure( (string) gf_apply_filters(
+			[ 'gfexcel_renderer_csv_enclosure', $form_id ],
+			$objWriter->getEnclosure(),
+			$form_id
+		) );
 
-        // whether to use a BOM
-	    $use_bom = apply_filters( 'gform_include_bom_export_entries', $objWriter->getUseBOM() );
-	    $objWriter->setUseBOM( (bool) apply_filters( 'gfexcel_renderer_csv_use_bom', $use_bom ) );
+		// updates the line ending
+		$objWriter->setLineEnding( (string) gf_apply_filters(
+			[ 'gfexcel_renderer_csv_line_ending', $form_id ],
+			$objWriter->getLineEnding(),
+			$form_id
+		) );
 
-        // whether to include a separator line
-        $objWriter->setIncludeSeparatorLine((bool) apply_filters(
-            'gfexcel_renderer_csv_include_separator_line',
-            $objWriter->getIncludeSeparatorLine()
-        ));
-    }
+		// whether to use a BOM
+		$use_bom = apply_filters( 'gform_include_bom_export_entries', $objWriter->getUseBOM(), $this->form );
+		$objWriter->setUseBOM( (bool) gf_apply_filters(
+			[ 'gfexcel_renderer_csv_use_bom', $form_id ],
+			$use_bom,
+			$form_id
+		) );
+
+		// whether to include a separator line
+		$objWriter->setIncludeSeparatorLine( (bool) gf_apply_filters(
+			[ 'gfexcel_renderer_csv_include_separator_line', $form_id ],
+			$objWriter->getIncludeSeparatorLine(),
+			$form_id
+		) );
+	}
 }

--- a/src/Renderer/PHPExcelRenderer.php
+++ b/src/Renderer/PHPExcelRenderer.php
@@ -4,11 +4,10 @@ namespace GFExcel\Renderer;
 
 use GFExcel\GFExcel;
 
-class PHPExcelRenderer extends AbstractPHPExcelRenderer implements RendererInterface
+class PHPExcelRenderer extends AbstractPHPExcelRenderer
 {
     private $columns;
     private $rows;
-    private $form;
     private $worksheet;
     private $extension;
 


### PR DESCRIPTION
This MR closes #117 and adds the form id as an extra parameter for all `gfexcel_renderer_csv_*` hooks.  This makes for more specific targeting like: 

```php
// Update delimiter to ; for form 12.
add_filter('gfexcel_renderer_csv_delimiter_12', fn() => ';');
```