### PR TITLE
Show upgrade message when pro is NOT installed

### DIFF
--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -225,7 +225,7 @@ class GFExcelAdmin extends \GFAddOn implements AddonInterface
             ]
         ];
 
-	    if ( class_exists( 'GravityKit\GravityExport\GravityExport' ) ) {
+	    if ( ! class_exists( 'GravityKit\GravityExport\GravityExport' ) ) {
 		    $settings_sections[] = [
 			    'title'       => '',
 			    'description' => $this->get_gravityexport_message(),


### PR DESCRIPTION
Currently the plugin settings will show the upgrade section when the pro plugin is actually already installed. It should do the opposite :-) 