### PR TITLE
Added transformer for `likert` field

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Feature: Survey Likert fields can return the score instead of the value by applying the `gfexcel_field_likert_use_score` hook.
+
 = 1.10.1 on December 10, 2021 =
 
 * Bufgix: Fatal error when using the plugin with PHP <7.4.

--- a/src/Field/AbstractField.php
+++ b/src/Field/AbstractField.php
@@ -120,7 +120,7 @@ abstract class AbstractField implements FieldInterface
      *
      * @param array $entry The entry object.
      * @param string $input_id The id of the input field.
-     * @return array|string The value of the field.
+     * @return array|string|int The value of the field. May be `0` if not found.
      */
     protected function getFieldValue($entry, $input_id = '')
     {

--- a/src/Field/ProductField.php
+++ b/src/Field/ProductField.php
@@ -11,11 +11,11 @@ use GFExcel\Values\StringValue;
 class ProductField extends SeparableField
 {
     /** @var string */
-    const SETTING_KEY = 'numeric_price_enabled';
+    public const SETTING_KEY = 'numeric_price_enabled';
 
     /**
      * {@inheritdoc}
-     * Usual code, but with a prepend for quantity and price for single field rendering.
+     * Usual code, but with a prepended string for quantity and price for single field rendering.
      */
     protected function getSeparatedFields($entry)
     {

--- a/src/Field/SurveyLikertField.php
+++ b/src/Field/SurveyLikertField.php
@@ -23,16 +23,27 @@ class SurveyLikertField extends SeparableField {
 			return parent::getFieldValue( $entry, $input_id );
 		}
 
-		$value = $entry[ $input_id ?: $this->field->id ] ?? ':';
+		if( $input_id ) {
+			$entry_key = $input_id;
+		} else {
+			$entry_key = $this->field->id;
+		}
+
+		$value = $entry[ $entry_key ] ?? '';
+
 		// If this is not a multi row value; add a colon, so we can still get $column.
 		if ( strpos( $value, ':' ) === false ) {
 			$value = ':' . $value;
 		}
 
+		// There will always be a colon; there will always be a $column set.
 		[ , $column ] = explode( ':', $value );
 
 		foreach ( $this->field->choices as $choice ) {
-			if ( ( $choice['value'] ?? '' ) === $column ) {
+
+			$choice_value = $choice['value'] ?? '';
+
+			if ( $choice_value === $column ) {
 				return $choice['score'];
 			}
 		}

--- a/src/Field/SurveyLikertField.php
+++ b/src/Field/SurveyLikertField.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace GFExcel\Field;
+
+/**
+ * A field transformer for the `likert` field from the Gravity Forms Survey Plugin.
+ * @since $ver$
+ * @see \GF_Field_Likert
+ */
+class SurveyLikertField extends SeparableField {
+	/**
+	 * @inheritdoc
+	 * @var \GF_Field_Likert
+	 */
+	protected $field;
+
+	/**
+	 * @inheritdoc
+	 * @since $ver$
+	 */
+	public function getFieldValue( $entry, $input_id = '' ) {
+		if ( ! $this->useScoreOutput() ) {
+			return parent::getFieldValue( $entry, $input_id );
+		}
+
+		$value = $entry[ $input_id ?: $this->field->id ] ?? ':';
+		// If this is not a multi row value; add a colon, so we can still get $column.
+		if ( strpos( $value, ':' ) === false ) {
+			$value = ':' . $value;
+		}
+
+		[ , $column ] = explode( ':', $value );
+
+		foreach ( $this->field->choices as $choice ) {
+			if ( ( $choice['value'] ?? '' ) === $column ) {
+				return $choice['score'];
+			}
+		}
+
+		return 0; // choice not found, so value is 0
+	}
+
+	/**
+	 * Whether to use the score instead of the text value.
+	 * @since $ver$
+	 * @return bool Whether to use the score as output.
+	 */
+	private function useScoreOutput(): bool {
+		return gf_apply_filters( [
+			'gfexcel_field_likert_use_score',
+			$this->field->formId,
+			$this->field->id,
+		], false, $this->field );
+	}
+
+	/**
+	 * @inheritdoc
+	 *
+	 * Overwritten so single row fields will still return the correct columns.
+	 *
+	 * @since $ver$
+	 */
+	protected function isSeparationEnabled() {
+		return parent::isSeparationEnabled() && $this->hasMultipleRows();
+	}
+
+	/**
+	 *
+	 * @since $ver$
+	 */
+	protected function hasMultipleRows(): bool {
+		return $this->field->gsurveyLikertEnableMultipleRows ?? false;
+	}
+
+	/**
+	 * @inheritdoc
+	 *
+	 * Overwritten so single row values will also be retrieved.
+	 *
+	 * @since $ver$
+	 */
+	public function getCells( $entry ) {
+		return $this->hasMultipleRows()
+			? parent::getCells( $entry )
+			: BaseField::getCells( $entry );
+	}
+}

--- a/src/Field/SurveyLikertField.php
+++ b/src/Field/SurveyLikertField.php
@@ -68,7 +68,7 @@ class SurveyLikertField extends SeparableField {
 	 * Whether this field has multiple rows.
 	 * @since $ver$
 	 */
-	protected function hasMultipleRows(): bool {
+	private function hasMultipleRows(): bool {
 		return $this->field->gsurveyLikertEnableMultipleRows ?? false;
 	}
 

--- a/src/Field/SurveyLikertField.php
+++ b/src/Field/SurveyLikertField.php
@@ -65,7 +65,7 @@ class SurveyLikertField extends SeparableField {
 	}
 
 	/**
-	 *
+	 * Whether this field has multiple rows.
 	 * @since $ver$
 	 */
 	protected function hasMultipleRows(): bool {

--- a/src/GFExcelAdmin.php
+++ b/src/GFExcelAdmin.php
@@ -729,7 +729,7 @@ class GFExcelAdmin extends \GFAddOn implements AddonInterface
 
         // get_posted_settings() doesn't capture all the settings added using the `gfexcel_general_settings` filter,
         // so we add the values back in here.
-        return array_merge($settings, array_reduce(array_keys($form), function ($settings, $key) use ($form, $extra_settings) {
+        return array_merge($settings, array_reduce(array_keys($form), function ($settings, $key) use ($form) {
 
             if ( stripos($key, 'gfexcel_') === 0 || stripos($key, 'gravityexport') === 0 ) {
                 $settings[$key] = $form[$key];

--- a/src/Transformer/Transformer.php
+++ b/src/Transformer/Transformer.php
@@ -23,6 +23,7 @@ class Transformer
         'date' => 'GFExcel\Field\DateField',
         'fileupload' => 'GFExcel\Field\FileUploadField',
         'form' => 'GFExcel\Field\NestedFormField',
+        'likert' => 'GFExcel\Field\SurveyLikertField',
         'list' => 'GFExcel\Field\ListField',
         'meta' => 'GFExcel\Field\MetaField',
         'name' => 'GFExcel\Field\SeparableField',


### PR DESCRIPTION
This MR closes #82 

It adds a Field Transformer for the Likert field from the Gravity Forms Survey Plugin. 

This transformer has a `gfexcel_field_likert_use_score` hook that will output the field value as the score instead of the string value, when the resulting value is `true`. 

```php
// Let `likert` fields return their score.
add_filter('gfexcel_field_likert_use_score', '__return_true');
```

After merging https://wordpress.org/support/topic/survey-scores-per-entry/#post-13830055 can also be updated to include the new solution. Their solution should however keep working.