### PR TITLE
Fixed custom label retrieval on PHP 8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -262,6 +262,7 @@ You can hide a row by adding a hook. Checkout this example:
 * Enhancement: Nested form field values are formatted properly through transformers.
 * Bugfix: Sort order of nested form fields could be swapped on some entries.
 * Bugfix: Transposed PDFs could have extra empty columns.
+* Bugfix: Download of nested forms could fail on PHP 8
 
 = 1.11 on January 31, 2022 =
 

--- a/src/Field/SeparableField.php
+++ b/src/Field/SeparableField.php
@@ -121,12 +121,11 @@ class SeparableField extends BaseField
      * @param array|\ArrayAccess $field The field object.
      * @return string The sub label.
      */
-    protected function getSubLabel($field)
-    {
-        if (!array_key_exists('customLabel', $field) || empty(trim($field['customLabel']))) {
-            return $field['label'];
-        }
+	protected function getSubLabel( $field ) {
+		if ( empty( trim( $field['customLabel'] ?? '' ) ) ) {
+			return $field['label'];
+		}
 
-        return $field['customLabel'];
-    }
+		return $field['customLabel'];
+	}
 }


### PR DESCRIPTION
The behavior of `array_key_exists` changed in PHP 8, and it no longer accepts an array-like object; but only arrays. This causes an issue on the `SeparableField` which gets a custom sublabel through this method on the field object.

This PR fixes the problem by using the `\ArrayAccess` ability in combination with the Null Coalescing Operator (`??`).
