### PR TITLE
Empty string check to naive on Combiner

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -260,10 +260,8 @@ You can hide a row by adding a hook. Checkout this example:
 = Unreleased [1.11.2] =
 
 * Enhancement: Added `date_updated` as a default exported meta-field.
-
-= Unreleased [1.11.2] =
-
 * Bugfix: Filtering using `in` and `not in` operators in the URL query string did not work.
+* Bugfix: The value `0` was not combined properly with other values on fields with multiple values.
 
 = 1.11.1 on June 20, 2022 =
 

--- a/src/Transformer/Combiner.php
+++ b/src/Transformer/Combiner.php
@@ -51,9 +51,10 @@ class Combiner implements CombinerInterface
                 continue;
             }
 
+
             // Multiple rows, so we need to combine, and we MUST have a StringValue object.
             $combined = array_reduce($values, static function (string $output, BaseValue $value): string {
-                if (!empty($output)) {
+                if ($output !== '') {
                     $output .= gf_apply_filters([
                         'gfexcel_combiner_glue',
                         $value->getFieldType(),

--- a/src/Transformer/Combiner.php
+++ b/src/Transformer/Combiner.php
@@ -51,7 +51,6 @@ class Combiner implements CombinerInterface
                 continue;
             }
 
-
             // Multiple rows, so we need to combine, and we MUST have a StringValue object.
             $combined = array_reduce($values, static function (string $output, BaseValue $value): string {
                 if ($output !== '') {


### PR DESCRIPTION
On the `Combiner.php` there is an `empty` check, to see if it should append a separation line. 

Because it was using `empty()` it considers the value `0` as empty, and omits the separation line.