### PR TITLE
Added label filter on List Field columns

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Enhancement: List fields column labels can now be manipulated by the `gfexcel_field_label` filter.
+
 = 1.11.2 on July 19, 2022 =
 
 * Enhancement: Added `date_updated` as a default exported meta field.

--- a/src/Field/ListField.php
+++ b/src/Field/ListField.php
@@ -8,94 +8,96 @@ use GFExcel\Values\BaseValue;
  * Field transformer that represents a List field
  * @since 1.3.0
  */
-class ListField extends BaseField implements RowsInterface
-{
-    private $columns;
+class ListField extends BaseField implements RowsInterface {
+	private $columns;
 
-    /**
-     * @inheritdoc
-     * @since 1.8.10
-     */
-    public function __construct(\GF_Field $field)
-    {
-        parent::__construct($field);
+	/**
+	 * @inheritdoc
+	 * @since 1.8.10
+	 */
+	public function __construct( \GF_Field $field ) {
+		parent::__construct( $field );
 
-        // Normal glue
-        add_filter('gfexcel_combiner_glue_list', static function () {
-            return "\n";
-        });
-    }
+		// Normal glue
+		add_filter( 'gfexcel_combiner_glue_list', static function () {
+			return "\n";
+		} );
+	}
 
-    /**
-     * Array of needed column names for this field.
-     * @return BaseValue[]|string[]
-     */
-    public function getColumns()
-    {
-        if (!$this->columns) {
-            if (!$this->field['enableColumns']) {
-                //no columns, so we can just use the field name, and a single column
-                $this->columns = parent::getColumns(); //micro caching
+	/**
+	 * Array of needed column names for this field.
+	 * @return BaseValue[]|string[]
+	 */
+	public function getColumns() {
+		if ( ! $this->columns ) {
+			if ( ! $this->field['enableColumns'] ) {
+				//no columns, so we can just use the field name, and a single column
+				$this->columns = parent::getColumns(); //micro caching
 
-                return $this->columns;
-            }
+				return $this->columns;
+			}
 
-            //Multiple columns, so lets get their names, and return multiple columns.
-            $this->columns = array_map(static function ($choice) {
-                return $choice['value'];
-            }, (array) $this->field['choices']);
-        }
+			//Multiple columns, so lets get their names, and return multiple columns.
+			$this->columns = array_map( function ( $choice ) {
+				return gf_apply_filters( [
+					'gfexcel_field_label',
+					$this->field->get_input_type(),
+					$this->field->formId,
+					$this->field->id
+				], $choice['value'], $this->field );
+			}, (array) $this->field['choices'] );
+		}
 
-        return $this->wrap($this->columns, true);
-    }
+		return $this->wrap( $this->columns, true );
+	}
 
-    /**
-     * Array of needed cell values for this field
-     * @param array $entry
-     * @return BaseValue[]
-     */
-    public function getCells($entry)
-    {
-        $rows = iterator_to_array($this->getRows($entry));
-        $result = array_reduce($rows, static function (array $combined, array $row): array {
-            foreach ($row as $i => $cell) {
-                $combined[$i][] = $cell->getValue();
-            }
+	/**
+	 * Array of needed cell values for this field
+	 *
+	 * @param array $entry
+	 *
+	 * @return BaseValue[]
+	 */
+	public function getCells( $entry ) {
+		$rows   = iterator_to_array( $this->getRows( $entry ) );
+		$result = array_reduce( $rows, static function ( array $combined, array $row ): array {
+			foreach ( $row as $i => $cell ) {
+				$combined[ $i ][] = $cell->getValue();
+			}
 
-            return $combined;
-        }, []);
+			return $combined;
+		}, [] );
 
-        // Every value on it's own line for readability.
-        return $this->wrap(array_map(static function (array $column) {
-            return implode("\n", $column);
-        }, $result));
-    }
+		// Every value on its own line for readability.
+		return $this->wrap( array_map( static function ( array $column ) {
+			return implode( "\n", $column );
+		}, $result ) );
+	}
 
-    /**
-     * @inheritdoc
-     * @since 1.8.0
-     */
-    public function getRows(?array $entry = null): iterable
-    {
-        if (!$this->field['enableColumns']) {
-            // One column, so the input is a single string
-            yield parent::getCells($entry);
-        } else {
-            $value = $this->getFieldValue($entry);
-            if (!$result = json_decode($value, true)) {
-                yield $this->wrap(array_map(static function () {
-                    return '';
-                }, $this->getColumns()));
-            } else {
-                foreach ($result as $row) {
-                    $result = [];
-                    foreach ($this->getColumns() as $column) {
-                        $column = $column instanceof BaseValue ? $column->getValue() : $column;
-                        $result[$column] = $row[$column] ?? null;
-                    }
-                    yield $this->wrap(array_values($result));
-                }
-            }
-        }
-    }
+	/**
+	 * @inheritdoc
+	 * @since 1.8.0
+	 */
+	public function getRows( ?array $entry = null ): iterable {
+		if ( ! $this->field['enableColumns'] ) {
+			// One column, so the input is a single string
+			yield parent::getCells( $entry );
+		} else {
+			$value   = $this->getFieldValue( $entry );
+			$columns = array_column( $this->field['choices'], 'value' );
+			if ( ! $result = json_decode( $value, true ) ) {
+				yield $this->wrap( array_map( static function () {
+					return '';
+				}, $columns ) );
+			} else {
+				foreach ( $result as $row ) {
+					$result = [];
+					foreach ( $columns as $column ) {
+						$result[ $column ] = $row[ $column ] ?? null;
+					}
+					yield $this->wrap( array_values( $result ) );
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
This MR resolves #144.

Since `getColumns()` now potentially returns a different name we can no longer rely on it in the `getRows()` method. Therefor I extracted the original columns names in a separate variable. Good old `array_column()` once again shines here!