### PR TITLE
Added ID as sort option

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= Unreleased =
+
+* Enhancement: Added `Entry ID` as a sorting option. Useful when duplicate entry dates exist.
+
 = 1.11.3 on September 29, 2022 =
 
 * Enhancement: List fields column labels can now be manipulated by the `gfexcel_field_label` filter.

--- a/src/Repository/FieldsRepository.php
+++ b/src/Repository/FieldsRepository.php
@@ -268,11 +268,15 @@ class FieldsRepository
 
             return $fields;
         }, [
-            // Add `date of entry` as first item.
-            [
-                'value' => 'date_created',
-                'label' => __('Date of entry', GFExcel::$slug),
-            ]
+	        // Add `date of entry` and `entry id` as first items.
+	        [
+		        'value' => 'date_created',
+		        'label' => __( 'Date of entry', GFExcel::$slug ),
+	        ],
+	        [
+		        'value' => 'id',
+		        'label' => __( 'Entry Id', 'gravityforms' ),
+	        ],
         ]);
     }
 }


### PR DESCRIPTION
For an Issue for @rafaehlers I found we could not sort by ID by default. In this case it was very useful because order by DATE caused unwanted results when duplicate dates existed. And since GravityForms does not support sorting by multiple columns the best thing we can do is sort by Entry ID (which theoretically is in the same order as the entry date).