### PR TITLE
Add GFEXCEL_AVOID_CLASS_ALIAS constant to prevent class alias conflicts

### DIFF
--- a/gfexcel.php
+++ b/gfexcel.php
@@ -71,6 +71,7 @@ add_action( 'gform_loaded', static function (): void {
 	$autoload_file = __DIR__ . '/build/vendor/autoload.php';
 
 	$is_build = true;
+	$can_add_class_alias = ! defined( 'GFEXCEL_AVOID_CLASS_ALIAS' ) || ! GFEXCEL_AVOID_CLASS_ALIAS;
 	if ( ! file_exists( $autoload_file ) ) {
 		$autoload_file = __DIR__ . '/vendor/autoload.php';
 		$is_build      = false;
@@ -78,7 +79,7 @@ add_action( 'gform_loaded', static function (): void {
 
 	require_once $autoload_file;
 
-	if ( $is_build ) {
+	if ( $is_build && $can_add_class_alias ) {
 		// Make old class names available as aliases if possible.
 		$class_aliases = [
 			'PhpOffice\PhpSpreadsheet\Document\Properties',

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Enhancement: Defining a `GFEXCEL_AVOID_CLASS_ALIAS` constant as `true` will avoid registering PHPSpreadsheet class aliases.
+
 = 2.4.0 on July 10, 2025 =
 
 * Changed: Updated download link handling to allow future enhancements.


### PR DESCRIPTION
This PR addresses #221 in the nicest way we can.

- Introduced `GFEXCEL_AVOID_CLASS_ALIAS` constant to conditionally skip PHPSpreadsheet class alias registration
- Allows plugins to avoid conflicts when other plugins also use PHPSpreadsheet
- Updated changelog to document this enhancement

This resolves potential conflicts with plugins like WebToffee Import Export that may use the same PHPSpreadsheet library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Added an option to disable legacy PhpSpreadsheet class aliases by defining the GFEXCEL_AVOID_CLASS_ALIAS constant as true, allowing more control over class aliasing during runtime.
* Documentation
  - Updated the changelog to document the new option for avoiding class alias registration and clarified its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->