### PR TITLE
Fix: Prevent error handeling of suppressed warning (GEXPLIT-7)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,10 +256,6 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= develop =
-
-* Fixed: WordPress no longer logs suppressed warnings emitted by 'MetaField' tests.
-
 = 2.5.0 on January 29, 2026 =
 
 * Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.
@@ -270,6 +266,7 @@ You can hide a row by adding a hook. Checkout this example:
     - Proper ARIA labels on all interactive elements.
 * Improved: RTL (right-to-left) language support for the field selector interface.
 * Enhancement: Added filter hooks change the separator used to combine complex fields, like Name and Address.
+* Fixed: WordPress no longer logs suppressed warnings emitted by "MetaField" tests.
 
 __Developer Updates:__
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Fixed: WordPress no longer logs suppressed warnings emitted by 'MetaField' tests.
+
 = 2.5.0 on January 29, 2026 =
 
 * Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.

--- a/src/Field/MetaField.php
+++ b/src/Field/MetaField.php
@@ -4,84 +4,84 @@ namespace GFExcel\Field;
 
 use GFExcel\Values\BaseValue;
 
-class MetaField extends BaseField implements RowsInterface
-{
-    /**
-     * List of internal subfields.
-     * @var string[]
-     */
-    protected $subfields = [
-        'created_by' => 'GFExcel\Field\Meta\CreatedBy',
-        'date_created' => 'GFExcel\Field\Meta\DateCreated',
-	    '/gpml_ids_\d+/is' => 'GFExcel\Field\Meta\GPMediaLibrary',
-    ];
+/**
+ * Represents a meta-field on an entry.
+ */
+class MetaField extends BaseField implements RowsInterface {
+	/**
+	 * List of internal subfields.
+	 * @var string[]
+	 */
+	protected $subfields = [
+		'created_by'       => 'GFExcel\Field\Meta\CreatedBy',
+		'date_created'     => 'GFExcel\Field\Meta\DateCreated',
+		'/gpml_ids_\d+/is' => 'GFExcel\Field\Meta\GPMediaLibrary',
+	];
 
-    /**
-     * {@inheritdoc}
-     * @return BaseValue[]
-     */
-    public function getColumns()
-    {
-        if ($subfield = $this->getSubField()) {
-            return $subfield->getColumns();
-        }
+	/**
+	 * {@inheritdoc}
+	 * @return BaseValue[]
+	 */
+	public function getColumns() {
+		if ( $subfield = $this->getSubField() ) {
+			return $subfield->getColumns();
+		}
 
-        return parent::getColumns();
-    }
+		return parent::getColumns();
+	}
 
-    /**
-     * {@inheritdoc}
-     * @param array $entry
-     * @return BaseValue[]
-     */
-    public function getCells($entry)
-    {
-        if ($subfield = $this->getSubField()) {
-            return $subfield->getCells($entry);
-        }
+	/**
+	 * {@inheritdoc}
+	 * @param array $entry
+	 *
+	 * @return BaseValue[]
+	 */
+	public function getCells( $entry ) {
+		if ( $subfield = $this->getSubField() ) {
+			return $subfield->getCells( $entry );
+		}
 
-        $value = $this->getFieldValue($entry);
-        $value = gf_apply_filters([
-            'gfexcel_meta_value',
-            $this->field->id,
-            $this->field->formId,
-        ], $value, $entry, $this->field);
+		$value = $this->getFieldValue( $entry );
+		$value = gf_apply_filters( [
+			'gfexcel_meta_value',
+			$this->field->id,
+			$this->field->formId,
+		], $value, $entry, $this->field );
 
-        return $this->wrap([$value]);
-    }
+		return $this->wrap( [ $value ] );
+	}
 
-    /**
-     * {@inheritdoc}
-     * @return string
-     */
-    public function getValueType()
-    {
-        if (in_array($this->field->id, [
-            'id',
-            'form_id',
-            'created_by'
-        ])) {
-            return BaseValue::TYPE_NUMERIC;
-        }
-        //default
-        return BaseValue::TYPE_STRING;
-    }
+	/**
+	 * {@inheritdoc}
+	 * @return string
+	 */
+	public function getValueType() {
+		if ( in_array( $this->field->id, [
+			'id',
+			'form_id',
+			'created_by'
+		] ) ) {
+			return BaseValue::TYPE_NUMERIC;
+		}
 
-    /**
-     * Returns a list of classnames map for meta fields. 'field' => 'FQN'
-     * @return string[]
-     */
-    private function getSubFieldsClasses()
-    {
-        return gf_apply_filters([
-            'gfexcel_transformer_subfields',
-        ], $this->subfields);
-    }
+		//default
+		return BaseValue::TYPE_STRING;
+	}
 
-    /**
-     * Get a subfield instance if available.
-     * @return FieldInterface|null
-     */
+	/**
+	 * Returns a list of classnames map for meta fields. 'field' => 'FQN'
+	 * @return string[]
+	 */
+	private function getSubFieldsClasses() {
+		return gf_apply_filters( [
+			'gfexcel_transformer_subfields',
+		], $this->subfields );
+	}
+
+	/**
+	 * Get a subfield instance if available.
+	 * @return FieldInterface|null
+	 */
 	private function getSubField() {
 		// prevent endless loop, and be able to extend MetaField.
 		if ( get_class( $this ) !== self::class ) {
@@ -95,6 +95,10 @@ class MetaField extends BaseField implements RowsInterface
 
 		foreach ( $fields as $name => $field ) {
 			// Check if one of the fields is actually a regex.
+			if ( ! $this->is_valid_regex( $name ) ) {
+				continue;
+			}
+
 			if ( @ preg_match( $name, $this->field->id ) ) {
 				return new $field( $this->field );
 			}
@@ -109,10 +113,31 @@ class MetaField extends BaseField implements RowsInterface
 	 */
 	public function getRows( ?array $entry = null ): iterable {
 		$subfield = $this->getSubField();
-		if ($subfield instanceof RowsInterface) {
-			yield from $subfield->getRows($entry);
+		if ( $subfield instanceof RowsInterface ) {
+			yield from $subfield->getRows( $entry );
 		} else {
-			yield $this->getCells($entry);
+			yield $this->getCells( $entry );
+		}
+	}
+
+	/**
+	 * Returns whether the provided pattern is a valid regex.
+	 *
+	 * @since $ver$
+	 *
+	 * @param string $pattern The string to check.
+	 *
+	 * @return bool Whether the provided pattern is a valid regex.
+	 */
+	private function is_valid_regex( string $pattern ): bool {
+		try {
+			// Prevent logging the warning if the pattern is not valid (php 8+).
+			set_error_handler( '__return_true', E_WARNING );
+
+			return @preg_match( $pattern, '' ) !== false;
+		} finally {
+			// Ensure error handler is restored.
+			restore_error_handler();
 		}
 	}
 }


### PR DESCRIPTION
This PR is in response to https://wordpress.org/support/topic/wordpress-error-preg_match-delimiter-must-not-be-alpha/

It should prevent logging of warnings by WordPress. Even though the warning was suppressed, a WordPress exception logger might catch on early. This replaces that logger temporarily. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WordPress from logging suppressed warnings emitted during MetaField tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](null) (718406c).