### PR TITLE
Add filter for combined subfield separator

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,16 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Enhancement: Added filter hooks change the separator used to combine complex fields, like name and address.
+
+__Developer Updates:__
+
+* Added: `gfexcel_field_separated_separator` hook.
+* Added: `gfexcel_field_<field type>_separator` hook, eg. `gfexcel_field_name_separator`.
+
+
 = 2.4.2 on January 7, 2026 =
 
 * Fixed: Added a deterministic sort order to prevent missing and duplicate entries.

--- a/src/Field/SeparableField.php
+++ b/src/Field/SeparableField.php
@@ -46,9 +46,25 @@ class SeparableField extends BaseField
 			return $this->wrap( $fields );
 		}
 
-		$value = $this->filter_value( implode( "\n", array_filter( $fields ) ), $entry );
+		$value = $this->filter_value( implode( $this->getCombinedFieldsSeparator(), array_filter( $fields ) ), $entry );
 
 		return $this->wrap( [ $value ] );
+	}
+
+	/**
+	 * Returns the separator used to combine subfield values when separation is disabled.
+	 *
+	 * @since TODO
+	 *
+	 * @return string The separator string.
+	 */
+	protected function getCombinedFieldsSeparator() {
+		return gf_apply_filters( [
+			'gfexcel_field_separated_separator',
+			$this->field->get_input_type(),
+			$this->field->formId,
+			$this->field->id,
+		], "\n", $this->field );
 	}
 
     /**

--- a/src/Field/SeparableField.php
+++ b/src/Field/SeparableField.php
@@ -9,23 +9,21 @@ use GFExcel\Values\BaseValue;
  * A field transformer that serves as the base for every field that has subfields.
  * @since 1.6.0
  */
-class SeparableField extends BaseField
-{
-    /** @var string */
-    public const SETTING_KEY = 'field_separation_enabled';
+class SeparableField extends BaseField {
+	/** @var string */
+	public const SETTING_KEY = 'field_separation_enabled';
 
-    /**
-     * @inheritdoc
-     * @return BaseValue[]
-     */
-    public function getColumns()
-    {
-        if (!$this->isSeparationEnabled()) {
-            return parent::getColumns();
-        }
+	/**
+	 * @inheritdoc
+	 * @return BaseValue[]
+	 */
+	public function getColumns() {
+		if ( ! $this->isSeparationEnabled() ) {
+			return parent::getColumns();
+		}
 
-        return $this->wrap($this->getSeparatedColumns(), true);
-    }
+		return $this->wrap( $this->getSeparatedColumns(), true );
+	}
 
 	/**
 	 * @inheritdoc
@@ -58,73 +56,88 @@ class SeparableField extends BaseField
 	 *
 	 * @return string The separator string.
 	 */
-	protected function getCombinedFieldsSeparator() {
+	protected function getCombinedFieldsSeparator(): string {
+		$glue = gf_apply_filters(
+			[
+				'gfexcel_field_separated_separator',
+				$this->field->get_input_type(),
+				$this->field->formId,
+				$this->field->id,
+			],
+			"\n",
+			$this->field
+		);
+
+		$glue = gf_apply_filters(
+			[
+				'gfexcel_field_' . $this->field->get_input_type() . '_separator',
+				$this->field->formId,
+				$this->field->id,
+			],
+			$glue,
+			$this->field
+		);
+
+		return (string) $glue;
+	}
+
+	/**
+	 * Get the separated fields to go along with the columns.
+	 *
+	 * @param mixed[] $entry The entry object.
+	 *
+	 * @return mixed[] The field values.
+	 */
+	protected function getSeparatedFields( $entry ) {
+		$entry_keys = array_keys( $this->getSeparatedColumns() );
+
+		return array_map( function ( $key ) use ( $entry ) {
+			return $this->getFieldValue( $entry, $key );
+		}, $entry_keys );
+	}
+
+	/**
+	 * Whether we should use separated fields.
+	 * @return bool Whether we should use separated fields.
+	 */
+	protected function isSeparationEnabled() {
+		$plugin = GravityExportAddon::get_instance();
+
 		return gf_apply_filters( [
-			'gfexcel_field_separated_separator',
+			'gfexcel_field_separated',
 			$this->field->get_input_type(),
 			$this->field->formId,
 			$this->field->id,
-		], "\n", $this->field );
+		], (bool) $plugin->get_plugin_setting( self::SETTING_KEY ), $this->field );
 	}
 
-    /**
-     * Get the separated fields to go along with the columns.
-     * @param mixed[] $entry The entry object.
-     * @return mixed[] The field values.
-     */
-    protected function getSeparatedFields($entry)
-    {
-        $entry_keys = array_keys($this->getSeparatedColumns());
+	/**
+	 * Get the column names for every active subfield.
+	 * @return array
+	 */
+	protected function getSeparatedColumns() {
+		return array_reduce( $this->getVisibleSubfields(), function ( $carry, $field ) {
+			$field_id           = (string) $field['id'];
+			$carry[ $field_id ] = gf_apply_filters( [
+				'gfexcel_field_label',
+				$this->field->get_input_type(),
+				$this->field->formId,
+				$this->field->id
+			], $this->getSubLabel( $field ), $this->field );
 
-        return array_map(function ($key) use ($entry) {
-            return $this->getFieldValue($entry, $key);
-        }, $entry_keys);
-    }
+			return $carry;
+		}, [] );
+	}
 
-    /**
-     * Whether we should use separated fields.
-     * @return bool Whether we should use separated fields.
-     */
-    protected function isSeparationEnabled()
-    {
-	    $plugin = GravityExportAddon::get_instance();
-
-	    return gf_apply_filters( [
-		    'gfexcel_field_separated',
-		    $this->field->get_input_type(),
-		    $this->field->formId,
-		    $this->field->id,
-	    ], (bool) $plugin->get_plugin_setting( self::SETTING_KEY ), $this->field );
-    }
-
-    /**
-     * Get the column names for every active subfield.
-     * @return array
-     */
-    protected function getSeparatedColumns()
-    {
-        return array_reduce($this->getVisibleSubfields(), function ($carry, $field) {
-            $field_id = (string) $field['id'];
-            $carry[$field_id] = gf_apply_filters([
-                'gfexcel_field_label',
-                $this->field->get_input_type(),
-                $this->field->formId,
-                $this->field->id
-            ], $this->getSubLabel($field), $this->field);
-            return $carry;
-        }, []);
-    }
-
-    /**
-     * Retrieve all active subfields for this field.
-     * @return array
-     */
-    protected function getVisibleSubfields()
-    {
-        return array_filter((array) $this->field->get_entry_inputs(), function ($subfield) {
-            return ! isset( $subfield['isHidden'] ) || ! $subfield['isHidden'];
-        });
-    }
+	/**
+	 * Retrieve all active subfields for this field.
+	 * @return array
+	 */
+	protected function getVisibleSubfields() {
+		return array_filter( (array) $this->field->get_entry_inputs(), function ( $subfield ) {
+			return ! isset( $subfield['isHidden'] ) || ! $subfield['isHidden'];
+		} );
+	}
 
 	/**
 	 * Get the label for a subfield.


### PR DESCRIPTION
## Summary

- Adds new `gfexcel_field_separated_separator` filter allowing customization of the separator used when combining subfield values (when "Multiple Columns" is disabled)
    - I chose to keep the old naming structure until we completely update the naming convention of the plugin.
- Maintains backwards compatibility by keeping `\n` as the default separator
- Filter supports the standard GravityExport pattern with modifiers for input type, form ID, and field ID

Fixes [GEXPORT-7](https://linear.app/gravitykit/issue/GEXPORT-7)

## Test plan

- [ ] Create a form with a Name field (complex field with subfields)
- [ ] Create an export with "Multiple Columns" disabled
- [ ] Verify default behavior: subfield values separated by line breaks
- [ ] Add filter to change separator to space:
  ```php
  add_filter('gfexcel_field_separated_separator', function() {
      return ' ';
  });
  ```
- [ ] Verify filter works: subfield values now separated by space

💾 [Build file](https://www.dropbox.com/scl/fi/yydursyk8gy9nxv54fsy7/gf-entries-in-excel-2.4.2-f8281f0.zip?rlkey=loyhfmmij7oekm5q7gcktmt4v&dl=1) (f8281f0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field separators for combined subfield values are now configurable via hooks; when separation is enabled subfields export to individual columns, otherwise values are joined using the customizable separator.
  * Subfield visibility and per-subfield column labels are respected during export for clearer output.

* **Documentation**
  * Changelog updated with developer notes describing the new separator hooks and how to customize them.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->