### PR TITLE
Release 2.5.0

### DIFF
--- a/gfexcel.php
+++ b/gfexcel.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     GravityExport Lite
- * Version:         2.4.2
+ * Version:         2.5.0
  * Plugin URI:      https://gfexcel.com
  * Description:     Export all Gravity Forms entries to Excel (.xlsx) or CSV via a secret shareable URL.
  * Author:          GravityKit
@@ -28,7 +28,7 @@ if ( ! defined( 'GFEXCEL_PLUGIN_FILE' ) ) {
 }
 
 if ( ! defined( 'GFEXCEL_PLUGIN_VERSION' ) ) {
-	define( 'GFEXCEL_PLUGIN_VERSION', '2.4.2' );
+	define( 'GFEXCEL_PLUGIN_VERSION', '2.5.0' );
 }
 
 if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {

--- a/public/css/gravityexport-lite.css
+++ b/public/css/gravityexport-lite.css
@@ -1,9 +1,125 @@
+/* Sort Fields Search */
+.gk-gravityexport-sort-fields__search {
+    grid-column: 1 / -1;
+    margin-bottom: 1em;
+}
+
+.gk-gravityexport-sort-fields__search-input-wrapper {
+    position: relative;
+    display: block;
+}
+
+.gform-settings-panel__content input[type=search].gk-gravityexport-sort-fields__search-input {
+    width: 100%;
+    padding: .6875rem 1rem .6875rem 2rem;
+    border: 1px solid #8c8f94;
+    border-radius: 4px;
+    font-size: 14px;
+    line-height: 1.4;
+    background-color: #fff;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.gform-settings-panel__content input[type=search].gk-gravityexport-sort-fields__search-input:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+    outline: none;
+}
+
+.gform-settings-panel__content input[type=search].gk-gravityexport-sort-fields__search-input::placeholder {
+    color: #757575;
+}
+
+.gk-gravityexport-sort-fields__search-icon {
+    position: absolute;
+    left: 12px;
+    right: auto;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #757575;
+    pointer-events: none;
+}
+
+.gk-gravityexport-sort-fields__search-status {
+    display: none;
+    margin-top: 8px;
+    padding: 10px 12px;
+    background-color: #f0f0f1;
+    border-radius: 4px;
+    color: #50575e;
+    font-size: 13px;
+}
+
+.gk-gravityexport-sort-fields__search-status.is-active {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.gk-gravityexport-sort-fields__search-status.is-no-results {
+    background-color: #fcf0f1;
+    color: #8a2424;
+}
+
+.gk-gravityexport-sort-fields__clear-search {
+    color: #2271b1;
+    text-decoration: none;
+    cursor: pointer;
+    white-space: nowrap;
+    margin-left: 1em;
+}
+
+.gk-gravityexport-sort-fields__clear-search:hover,
+.gk-gravityexport-sort-fields__clear-search:focus {
+    color: #135e96;
+    text-decoration: underline;
+    outline: none;
+    box-shadow: 0 0 0 2px #2271b1;
+    border-radius: 2px;
+}
+
+/* Hidden fields (filtered out) */
+ul.fields-select li.gk-gravityexport-sort-fields__hidden {
+    display: none !important;
+}
+
 #gform_setting_export-fields .gk-gravityexport-sort-fields {
     border: 0;
     padding: 0;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     column-gap: 1em;
+}
+
+/* Enable/Disable all buttons */
+.gk-gravityexport-sort-fields button {
+    background: none;
+    border: 0;
+    float: right;
+    margin-top: -30px;
+    color: #3e7da6;
+    cursor: pointer;
+    transition: color 0.15s ease-in-out;
+}
+
+.gk-gravityexport-sort-fields button:hover {
+    text-decoration: underline;
+}
+
+.gk-gravityexport-sort-fields button:focus {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+.gk-gravityexport-sort-fields button:focus:not(:focus-visible) {
+    outline: none;
+}
+
+.gk-gravityexport-sort-fields button:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 
 ul.fields-select {
@@ -48,11 +164,6 @@ ul.fields-select li > div.field span {
     text-overflow: ellipsis;
 }
 
-.rtl ul.fields-select .fa-bars {
-    margin-left: 8px;
-    margin-right: 0;
-}
-
 ul.fields-select li > div.move {
     font-weight: bold;
     padding: 0;
@@ -64,14 +175,32 @@ ul.fields-select li div.move:hover {
     color: #006899;
 }
 
+ul.fields-select li div.move:focus {
+    color: #006899;
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+ul.fields-select li div.move:focus:not(:focus-visible) {
+    outline: none;
+}
+
+ul.fields-select li div.move:focus-visible {
+    color: #006899;
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
 ul.fields-select li {
     display: flex;
     background-color: #f7f7f7;
     margin: 4px 0;
     padding: 6px;
     -webkit-transition: background-color 100ms ease-in-out, color 100ms ease-in-out;
-    -ms-transition: background-color 100ms ease-in-out, color 100ms ease-in-out;;
-    transition: background-color 100ms ease-in-out, color 100ms ease-in-out;;
+    -ms-transition: background-color 100ms ease-in-out, color 100ms ease-in-out;
+    transition: background-color 100ms ease-in-out, color 100ms ease-in-out;
 }
 
 ul.fields-select li:first-child {
@@ -91,6 +220,22 @@ ul.fields-select .ui-sortable-handle {
 
 ul.fields-select .ui-sortable-handle:hover {
     background-color: #F0F0F0;
+}
+
+ul.fields-select li:focus {
+    background-color: #F0F0F0;
+    outline: 2px solid #2271b1;
+    outline-offset: -2px;
+}
+
+ul.fields-select li:focus:not(:focus-visible) {
+    outline: none;
+}
+
+ul.fields-select li:focus-visible {
+    background-color: #F0F0F0;
+    outline: 2px solid #2271b1;
+    outline-offset: -2px;
 }
 
 ul.fields-select li.light-up {
@@ -194,4 +339,61 @@ fieldset.gk-gravityexport-download-file .gform-settings-panel__content {
 
 .gform-settings-panel .copy-short-code .success {
     margin-right: 1rem;
+}
+
+/* RTL Support */
+.rtl .gform-settings-panel__content input[type=search].gk-gravityexport-sort-fields__search-input {
+    padding: .6875rem 2rem .6875rem 1rem;
+}
+
+.rtl .gk-gravityexport-sort-fields__search-icon {
+    left: auto;
+    right: 12px;
+}
+
+.rtl .gk-gravityexport-sort-fields__clear-search {
+    margin-left: 0;
+    margin-right: 1em;
+}
+
+.rtl ul.fields-select li > div.field span {
+    margin-left: 0;
+    margin-right: 5px;
+}
+
+.rtl ul.fields-select .fa-bars {
+    margin-left: 8px;
+    margin-right: 0;
+}
+
+.rtl ul.fields-select .move .fa-arrow-right {
+    transform: scaleX(-1);
+}
+
+.rtl .gk-gravityexport-sort-fields button {
+    float: left;
+}
+
+.rtl .download-block .date-field {
+    margin-right: 0;
+    margin-left: 10px;
+}
+
+.rtl .gfexcel-addon-gravityexport-lite #gform_setting_order_by #gform_setting_sort_order {
+    margin-left: 0;
+    margin-right: 5px;
+}
+
+.rtl .gform-settings-field__download_url span.success {
+    margin: 10px 0 0 5px;
+}
+
+.rtl .gform-settings-panel .copy-short-code .input {
+    margin-right: 0;
+    margin-left: 1rem;
+}
+
+.rtl .gform-settings-panel .copy-short-code .success {
+    margin-right: 0;
+    margin-left: 1rem;
 }

--- a/public/js/gravityexport-lite.js
+++ b/public/js/gravityexport-lite.js
@@ -1,6 +1,76 @@
 var gfexcel_sortable;
 
-( function ( $ ) {
+( function ( $, sprintf ) {
+
+	// Delay before starting the light-up animation, allowing the DOM to update after appending.
+	var LIGHT_UP_DELAY = 10;
+
+	// Duration of the light-up highlight effect on a moved field.
+	var LIGHT_UP_DURATION = 200;
+
+	/**
+	 * Filter sortable field lists based on search input.
+	 *
+	 * @param {jQuery} $container The sort fields container.
+	 * @param {string} searchTerm The search term to filter by.
+	 * @param {Object} strings The i18n strings object.
+	 * @param {Array} buttons Array of button objects with $button, enableLabel, disableLabel properties.
+	 */
+	var filterFields = function ( $container, searchTerm, strings, buttons ) {
+		var $lists = $container.find( 'ul.fields-select' );
+		var $status = $container.find( '.gk-gravityexport-sort-fields__search-status' );
+		var $statusText = $container.find( '.gk-gravityexport-sort-fields__search-status-text' );
+		var normalizedSearch = searchTerm.toLowerCase().trim();
+		var totalVisible = 0;
+
+		$lists.each( function () {
+			var $list = $( this );
+
+			$list.find( 'li' ).each( function () {
+				var $item = $( this );
+				var fieldLabel = $item.find( '.field span' ).text().toLowerCase();
+
+				if ( normalizedSearch === '' || fieldLabel.indexOf( normalizedSearch ) !== -1 ) {
+					$item.removeClass( 'gk-gravityexport-sort-fields__hidden' ).attr( 'aria-hidden', 'false' );
+					totalVisible++;
+				} else {
+					$item.addClass( 'gk-gravityexport-sort-fields__hidden' ).attr( 'aria-hidden', 'true' );
+				}
+			} );
+		} );
+
+		// Update status message
+		if ( normalizedSearch === '' ) {
+			$status.removeClass( 'is-active is-no-results' );
+		} else {
+			var statusMessage;
+			if ( totalVisible === 0 ) {
+				statusMessage = strings.no_fields_match;
+				$status.addClass( 'is-no-results' );
+			} else if ( totalVisible === 1 ) {
+				statusMessage = strings.one_field_matches;
+				$status.removeClass( 'is-no-results' );
+			} else {
+				statusMessage = strings.n_fields_match.replace( '%d', totalVisible );
+				$status.removeClass( 'is-no-results' );
+			}
+			$statusText.text( statusMessage );
+			$status.addClass( 'is-active' );
+		}
+
+		// Update button labels based on search state
+		if ( buttons && buttons.length ) {
+			var isSearchActive = normalizedSearch !== '';
+			buttons.forEach( function ( btn ) {
+				var newLabel = isSearchActive ? btn.visibleLabel : btn.allLabel;
+				btn.$button.text( newLabel );
+			} );
+		}
+
+		// Refresh sortable to account for hidden items
+		$lists.sortable( 'refresh' );
+	};
+
 	var updateLists = function ( $elements ) {
 		$elements.each( function ( i, el ) {
 			var $input = $( el ).prevAll( 'input[type=hidden]' );
@@ -10,31 +80,107 @@ var gfexcel_sortable;
 
 	gfexcel_sortable = function ( elements, connector_class ) {
 		var $elements = $( elements );
-		var labels_i10n = typeof gravityexport_lite_strings !== 'undefined'
+		var strings = typeof gravityexport_lite_strings !== 'undefined'
 			? gravityexport_lite_strings
-			: { 'enable': 'Enable all', 'disable': 'Disable all' }; // Fallback to English
+			: {
+				'enable': 'Enable all',
+				'disable': 'Disable all',
+				'enable_visible': 'Enable visible',
+				'disable_visible': 'Disable visible',
+				'no_fields_match': 'No fields match your search.',
+				'one_field_matches': '1 field matches your search.',
+				'n_fields_match': '%d fields match your search.',
+				'field_moved': '%1$s moved to %2$s.',
+				'fields_moved': '%1$d fields moved to %2$s.',
+				'one_field_moved': '1 field moved to %2$s.'
+			};
+
+		// Track buttons for label updates during search
+		var buttons = [];
+
+		// Initialize container references
+		var $container = $elements.closest( '.gk-gravityexport-sort-fields' );
+		var $searchInput = $container.find( '.gk-gravityexport-sort-fields__search-input' );
+		var $clearSearch = $container.find( '.gk-gravityexport-sort-fields__clear-search' );
+
+		/**
+		 * Clear search and reset filter.
+		 */
+		var clearSearch = function () {
+			$searchInput.val( '' );
+			filterFields( $container, '', strings, buttons );
+			$searchInput.focus();
+		};
+
+		if ( $searchInput.length ) {
+			var debouncedFilter = _.debounce( function () {
+				filterFields( $container, $searchInput.val(), strings, buttons );
+			}, 150 );
+
+			$searchInput.on( 'input', debouncedFilter );
+
+			// Prevent form submission on Enter, clear search on Escape
+			$searchInput.on( 'keydown', function ( e ) {
+				if ( e.key === 'Enter' ) {
+					e.preventDefault();
+				} else if ( e.key === 'Escape' ) {
+					clearSearch();
+				}
+			} );
+
+			// Handle search input clear button (native browser clear)
+			$searchInput.on( 'search', function () {
+				filterFields( $container, $searchInput.val(), strings, buttons );
+			} );
+
+			// Handle clear search link click
+			$clearSearch.on( 'click', function ( e ) {
+				e.preventDefault();
+				clearSearch();
+			} );
+		}
 
 		$elements.each( function () {
 			var $list = $( this );
 			var send_to = '#' + $list.data( 'send-to' );
-			var label = send_to.indexOf( 'enabled' ) > 0 ? labels_i10n.enable : labels_i10n.disable;
-			var $move_all_button = $( '<button type="button">' + label + '</button>' );
+			var isEnableButton = send_to.indexOf( 'enabled' ) > 0;
+			var allLabel = isEnableButton ? strings.enable : strings.disable;
+			var visibleLabel = isEnableButton ? strings.enable_visible : strings.disable_visible;
+			var $move_all_button = $( '<button type="button">' + allLabel + '</button>' );
+
+			// Store button reference for label updates during search
+			buttons.push( {
+				$button: $move_all_button,
+				allLabel: allLabel,
+				visibleLabel: visibleLabel
+			} );
 
 			$move_all_button
-				// Add css via JS to hit add-ons.
-				.css( {
-					background: 'none',
-					border: 0,
-					float: 'right',
-					marginTop: '-30px',
-					color: '#3e7da6',
-					cursor: 'pointer'
-				} )
-				// Move all items to the `send-to` list when clicked.
+				// Move visible items to the `send-to` list when clicked.
 				.on( 'click', function () {
-					$list.find( 'li' ).appendTo( $( send_to ) );
+					// Only move items that are not hidden by search filter
+					var $itemsToMove = $list.find( 'li:not(.gk-gravityexport-sort-fields__hidden)' );
+					var count = $itemsToMove.length;
+
+					if ( count === 0 ) {
+						return;
+					}
+
+					var $targetList = $( send_to );
+					var targetLabel = $targetList.data( 'list-label' ) || '';
+
+					$itemsToMove.appendTo( $targetList );
 					$elements.sortable( 'refresh' );
 					updateLists( $elements );
+
+					// Announce the action to screen readers
+					var message;
+					if ( count === 1 ) {
+						message = sprintf( strings.one_field_moved, count, targetLabel );
+					} else {
+						message = sprintf( strings.fields_moved, count, targetLabel );
+					}
+					wp.a11y.speak( message );
 				} );
 
 			// Add the button before the list.
@@ -48,19 +194,44 @@ var gfexcel_sortable;
 			}
 		} ).disableSelection();
 
+		/**
+		 * Move a single field item to its target list.
+		 *
+		 * @param {jQuery} $moveButton The move button that was activated.
+		 */
+		var moveField = function ( $moveButton ) {
+			var $element = $moveButton.closest( 'li' );
+			var $sourceList = $element.closest( 'ul' );
+			var send_to = '#' + $sourceList.data( 'send-to' );
+			var $targetList = $( send_to );
+			var fieldLabel = $element.find( '.field span' ).text();
+			var targetLabel = $targetList.data( 'list-label' ) || '';
+
+			$element.appendTo( $targetList );
+			setTimeout( function () {
+				$element.addClass( 'light-up' );
+				setTimeout( function () {
+					$element.removeClass( 'light-up' );
+				}, LIGHT_UP_DURATION );
+			}, LIGHT_UP_DELAY );
+			$elements.sortable( 'refresh' );
+			updateLists( $elements );
+
+			// Announce the action to screen readers
+			var message = sprintf( strings.field_moved, fieldLabel, targetLabel );
+			wp.a11y.speak( message );
+		};
+
 		$elements
 			.on( 'click', '.move', function () {
-				var element = $( this ).closest( 'li' );
-				var send_to = '#' + element.closest( 'ul' ).data( 'send-to' );
-				element.appendTo( $( send_to ) );
-				setTimeout( function () {
-					element.addClass( 'light-up' );
-					setTimeout( function () {
-						element.removeClass( 'light-up' );
-					}, 200 );
-				}, 10 );
-				$elements.sortable( 'refresh' );
-				updateLists( $elements );
+				moveField( $( this ) );
+			} )
+			// Keyboard support for move button
+			.on( 'keydown', '.move', function ( e ) {
+				if ( e.key === 'Enter' || e.key === ' ' ) {
+					e.preventDefault();
+					moveField( $( this ) );
+				}
 			} );
 	};
 
@@ -100,4 +271,4 @@ var gfexcel_sortable;
 			$embedShortcodeEl.val( embedShortcode );
 		} );
 	} );
-} )( jQuery );
+} )( jQuery, wp.i18n.sprintf );

--- a/readme.txt
+++ b/readme.txt
@@ -259,14 +259,14 @@ You can hide a row by adding a hook. Checkout this example:
 = 2.5.0 on January 29, 2026 =
 
 * Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.
-* Improved: Accessibility support for the field selector:
-    - Screen reader announcements when fields are moved between lists;
-    - Keyboard navigation with Enter/Space to move fields and Escape to clear search;
-    - Visible focus indicators for keyboard users;
-    - Proper ARIA labels on all interactive elements.
-* Improved: RTL (right-to-left) language support for the field selector interface.
+* Enhancement: Accessibility support for the field selector:
+  - Screen reader announcements when fields are moved between lists;
+  - Keyboard navigation with Enter/Space to move fields and Escape to clear search;
+  - Visible focus indicators for keyboard users;
+  - Proper ARIA labels on all interactive elements.
+* Enhancement: RTL (right-to-left) language support for the field selector interface.
 * Enhancement: Added filter hooks change the separator used to combine complex fields, like Name and Address.
-* Fixed: WordPress no longer logs suppressed warnings emitted by "MetaField" tests.
+* Fixed: PHP warning when field names are used as regex patterns without proper delimiters.
 
 __Developer Updates:__
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,10 +256,6 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= develop =
-
-* Fixed: WordPress no longer logs suppressed warnings emitted by 'MetaField' tests.
-
 = 2.5.0 on January 29, 2026 =
 
 * Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.
@@ -270,6 +266,7 @@ You can hide a row by adding a hook. Checkout this example:
     - Proper ARIA labels on all interactive elements.
 * Improved: RTL (right-to-left) language support for the field selector interface.
 * Enhancement: Added filter hooks change the separator used to combine complex fields, like Name and Address.
+* Fixed: WordPress no longer logs suppressed warnings emitted by "MetaField" tests.
 
 __Developer Updates:__
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,15 +256,14 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= develop =
+= 2.5.0 on January 29, 2026 =
 
-* Enhancement: Added filter hooks change the separator used to combine complex fields, like name and address.
+* Enhancement: Added filter hooks change the separator used to combine complex fields, like Name and Address.
 
 __Developer Updates:__
 
-* Added: `gfexcel_field_separated_separator` hook.
-* Added: `gfexcel_field_<field type>_separator` hook, eg. `gfexcel_field_name_separator`.
-
+* Added: `gfexcel_field_separated_separator` filter to change the default separator for all combined subfields (default: newline).
+* Added: `gfexcel_field_{field_type}_separator` filter (e.g., `gfexcel_field_name_separator`) to change the separator for a specific field type.
 
 = 2.4.2 on January 7, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,16 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Enhancement: Added filter hooks change the separator used to combine complex fields, like name and address.
+
+__Developer Updates:__
+
+* Added: `gfexcel_field_separated_separator` hook.
+* Added: `gfexcel_field_<field type>_separator` hook, eg. `gfexcel_field_name_separator`.
+
+
 = 2.4.2 on January 7, 2026 =
 
 * Fixed: Added a deterministic sort order to prevent missing and duplicate entries.

--- a/readme.txt
+++ b/readme.txt
@@ -258,6 +258,13 @@ You can hide a row by adding a hook. Checkout this example:
 
 = develop =
 
+* Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.
+* Improved: Full accessibility support for the field selector:
+    - Screen reader announcements when fields are moved between lists
+    - Keyboard navigation with Enter/Space to move fields and Escape to clear search
+    - Visible focus indicators for keyboard users
+    - Proper ARIA labels on all interactive elements
+* Improved: RTL (right-to-left) language support for the field selector interface.
 * Enhancement: Added filter hooks change the separator used to combine complex fields, like name and address.
 
 __Developer Updates:__

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Fixed: WordPress no longer logs suppressed warnings emitted by 'MetaField' tests.
+
 = 2.5.0 on January 29, 2026 =
 
 * Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -752,10 +752,14 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 	 * @since 2.0.0
 	 */
 	public function styles(): array {
+		$css_file    = plugin_dir_path( GFEXCEL_PLUGIN_FILE ) . 'public/css/gravityexport-lite.css';
+		$css_version = file_exists( $css_file ) ? (string) filemtime( $css_file ) : $this->get_version();
+
 		return array_merge( parent::styles(), [
 			[
 				'handle'  => 'gravityexport_lite',
 				'src'     => $this->assets_dir . 'css/gravityexport-lite.css',
+				'version' => $css_version,
 				'enqueue' => [
 					[ 'admin_page' => 'form_settings', 'tab' => $this->get_slug() ],
 					[ 'admin_page' => 'plugin_settings', 'tab' => $this->get_slug() ],
@@ -769,6 +773,9 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 	 * @since 2.0.0
 	 */
 	public function scripts(): array {
+		$js_file    = plugin_dir_path( GFEXCEL_PLUGIN_FILE ) . 'public/js/gravityexport-lite.js';
+		$js_version = file_exists( $js_file ) ? (string) filemtime( $js_file ) : $this->get_version();
+
 		return array_merge( parent::scripts(), [
 			[
 				'handle'  => 'jquery-ui-sortable',
@@ -780,19 +787,17 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 				],
 			],
 			[
-				'handle'  => 'gravityexport_lite',
-				'src'     => $this->assets_dir . 'js/gravityexport-lite.js',
-				'strings' => [
-					'enable'  => esc_html__( 'Enable all', 'gk-gravityexport-lite' ),
-					'disable' => esc_html__( 'Disable all', 'gk-gravityexport-lite' ),
-				],
-				'enqueue' => [
+				'handle'   => 'gravityexport_lite',
+				'src'      => $this->assets_dir . 'js/gravityexport-lite.js',
+				'version'  => $js_version,
+				'enqueue'  => [
 					[
 						'admin_page' => 'form_settings',
 						'tab'        => $this->get_slug(),
 					],
 				],
-				'deps'    => [ 'jquery', 'jquery-ui-sortable', 'jquery-ui-datepicker' ],
+				'deps'     => [ 'jquery', 'jquery-ui-sortable', 'jquery-ui-datepicker' ],
+				'callback' => [ $this, 'localize_sortable_script' ],
 			],
 			[
 				'handle'  => 'gravityexport_lite_settings',

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -796,7 +796,7 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 						'tab'        => $this->get_slug(),
 					],
 				],
-				'deps'     => [ 'jquery', 'jquery-ui-sortable', 'jquery-ui-datepicker' ],
+				'deps'     => [ 'jquery', 'jquery-ui-sortable', 'jquery-ui-datepicker', 'underscore', 'wp-i18n', 'wp-a11y' ],
 				'callback' => [ $this, 'localize_sortable_script' ],
 			],
 			[
@@ -810,6 +810,32 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 				],
 				'deps'    => [ 'jquery' ],
 			],
+		] );
+	}
+
+	/**
+	 * Localize the sortable script with i18n strings.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return void
+	 */
+	public function localize_sortable_script(): void {
+		wp_localize_script( 'gravityexport_lite', 'gravityexport_lite_strings', [
+			'enable'              => esc_html__( 'Enable all', 'gk-gravityexport-lite' ),
+			'disable'             => esc_html__( 'Disable all', 'gk-gravityexport-lite' ),
+			'enable_visible'      => esc_html__( 'Enable visible', 'gk-gravityexport-lite' ),
+			'disable_visible'     => esc_html__( 'Disable visible', 'gk-gravityexport-lite' ),
+			'no_fields_match'     => esc_html__( 'No fields match your search.', 'gk-gravityexport-lite' ),
+			'one_field_matches'   => esc_html__( '1 field matches your search.', 'gk-gravityexport-lite' ),
+			/* translators: %d: number of fields matching the search */
+			'n_fields_match'      => esc_html__( '%d fields match your search.', 'gk-gravityexport-lite' ),
+			/* translators: %1$s: field name, %2$s: destination list name (e.g., "Enabled Fields") */
+			'field_moved'         => esc_html__( '%1$s moved to %2$s.', 'gk-gravityexport-lite' ),
+			/* translators: %1$d: number of fields, %2$s: destination list name (e.g., "Enabled Fields") */
+			'fields_moved'        => esc_html__( '%1$d fields moved to %2$s.', 'gk-gravityexport-lite' ),
+			/* translators: %1$d: number of fields, %2$s: destination list name (e.g., "Enabled Fields") */
+			'one_field_moved'     => esc_html__( '1 field moved to %2$s.', 'gk-gravityexport-lite' ),
 		] );
 	}
 

--- a/src/Field/MetaField.php
+++ b/src/Field/MetaField.php
@@ -123,7 +123,7 @@ class MetaField extends BaseField implements RowsInterface {
 	/**
 	 * Returns whether the provided pattern is a valid regex.
 	 *
-	 * @since $ver$
+	 * @since 2.5.0
 	 *
 	 * @param string $pattern The string to check.
 	 *

--- a/src/Field/MetaField.php
+++ b/src/Field/MetaField.php
@@ -4,84 +4,84 @@ namespace GFExcel\Field;
 
 use GFExcel\Values\BaseValue;
 
-class MetaField extends BaseField implements RowsInterface
-{
-    /**
-     * List of internal subfields.
-     * @var string[]
-     */
-    protected $subfields = [
-        'created_by' => 'GFExcel\Field\Meta\CreatedBy',
-        'date_created' => 'GFExcel\Field\Meta\DateCreated',
-	    '/gpml_ids_\d+/is' => 'GFExcel\Field\Meta\GPMediaLibrary',
-    ];
+/**
+ * Represents a meta-field on an entry.
+ */
+class MetaField extends BaseField implements RowsInterface {
+	/**
+	 * List of internal subfields.
+	 * @var string[]
+	 */
+	protected $subfields = [
+		'created_by'       => 'GFExcel\Field\Meta\CreatedBy',
+		'date_created'     => 'GFExcel\Field\Meta\DateCreated',
+		'/gpml_ids_\d+/is' => 'GFExcel\Field\Meta\GPMediaLibrary',
+	];
 
-    /**
-     * {@inheritdoc}
-     * @return BaseValue[]
-     */
-    public function getColumns()
-    {
-        if ($subfield = $this->getSubField()) {
-            return $subfield->getColumns();
-        }
+	/**
+	 * {@inheritdoc}
+	 * @return BaseValue[]
+	 */
+	public function getColumns() {
+		if ( $subfield = $this->getSubField() ) {
+			return $subfield->getColumns();
+		}
 
-        return parent::getColumns();
-    }
+		return parent::getColumns();
+	}
 
-    /**
-     * {@inheritdoc}
-     * @param array $entry
-     * @return BaseValue[]
-     */
-    public function getCells($entry)
-    {
-        if ($subfield = $this->getSubField()) {
-            return $subfield->getCells($entry);
-        }
+	/**
+	 * {@inheritdoc}
+	 * @param array $entry
+	 *
+	 * @return BaseValue[]
+	 */
+	public function getCells( $entry ) {
+		if ( $subfield = $this->getSubField() ) {
+			return $subfield->getCells( $entry );
+		}
 
-        $value = $this->getFieldValue($entry);
-        $value = gf_apply_filters([
-            'gfexcel_meta_value',
-            $this->field->id,
-            $this->field->formId,
-        ], $value, $entry, $this->field);
+		$value = $this->getFieldValue( $entry );
+		$value = gf_apply_filters( [
+			'gfexcel_meta_value',
+			$this->field->id,
+			$this->field->formId,
+		], $value, $entry, $this->field );
 
-        return $this->wrap([$value]);
-    }
+		return $this->wrap( [ $value ] );
+	}
 
-    /**
-     * {@inheritdoc}
-     * @return string
-     */
-    public function getValueType()
-    {
-        if (in_array($this->field->id, [
-            'id',
-            'form_id',
-            'created_by'
-        ])) {
-            return BaseValue::TYPE_NUMERIC;
-        }
-        //default
-        return BaseValue::TYPE_STRING;
-    }
+	/**
+	 * {@inheritdoc}
+	 * @return string
+	 */
+	public function getValueType() {
+		if ( in_array( $this->field->id, [
+			'id',
+			'form_id',
+			'created_by'
+		] ) ) {
+			return BaseValue::TYPE_NUMERIC;
+		}
 
-    /**
-     * Returns a list of classnames map for meta fields. 'field' => 'FQN'
-     * @return string[]
-     */
-    private function getSubFieldsClasses()
-    {
-        return gf_apply_filters([
-            'gfexcel_transformer_subfields',
-        ], $this->subfields);
-    }
+		//default
+		return BaseValue::TYPE_STRING;
+	}
 
-    /**
-     * Get a subfield instance if available.
-     * @return FieldInterface|null
-     */
+	/**
+	 * Returns a list of classnames map for meta fields. 'field' => 'FQN'
+	 * @return string[]
+	 */
+	private function getSubFieldsClasses() {
+		return gf_apply_filters( [
+			'gfexcel_transformer_subfields',
+		], $this->subfields );
+	}
+
+	/**
+	 * Get a subfield instance if available.
+	 * @return FieldInterface|null
+	 */
 	private function getSubField() {
 		// prevent endless loop, and be able to extend MetaField.
 		if ( get_class( $this ) !== self::class ) {
@@ -95,6 +95,10 @@ class MetaField extends BaseField implements RowsInterface
 
 		foreach ( $fields as $name => $field ) {
 			// Check if one of the fields is actually a regex.
+			if ( ! $this->is_valid_regex( $name ) ) {
+				continue;
+			}
+
 			if ( @ preg_match( $name, $this->field->id ) ) {
 				return new $field( $this->field );
 			}
@@ -109,10 +113,31 @@ class MetaField extends BaseField implements RowsInterface
 	 */
 	public function getRows( ?array $entry = null ): iterable {
 		$subfield = $this->getSubField();
-		if ($subfield instanceof RowsInterface) {
-			yield from $subfield->getRows($entry);
+		if ( $subfield instanceof RowsInterface ) {
+			yield from $subfield->getRows( $entry );
 		} else {
-			yield $this->getCells($entry);
+			yield $this->getCells( $entry );
+		}
+	}
+
+	/**
+	 * Returns whether the provided pattern is a valid regex.
+	 *
+	 * @since $ver$
+	 *
+	 * @param string $pattern The string to check.
+	 *
+	 * @return bool Whether the provided pattern is a valid regex.
+	 */
+	private function is_valid_regex( string $pattern ): bool {
+		try {
+			// Prevent logging the warning if the pattern is not valid (php 8+).
+			set_error_handler( '__return_true', E_WARNING );
+
+			return @preg_match( $pattern, '' ) !== false;
+		} finally {
+			// Ensure error handler is restored.
+			restore_error_handler();
 		}
 	}
 }

--- a/src/Field/SeparableField.php
+++ b/src/Field/SeparableField.php
@@ -52,7 +52,7 @@ class SeparableField extends BaseField {
 	/**
 	 * Returns the separator used to combine subfield values when separation is disabled.
 	 *
-	 * @since TODO
+	 * @since 2.5.0
 	 *
 	 * @return string The separator string.
 	 */

--- a/src/Field/SeparableField.php
+++ b/src/Field/SeparableField.php
@@ -9,23 +9,21 @@ use GFExcel\Values\BaseValue;
  * A field transformer that serves as the base for every field that has subfields.
  * @since 1.6.0
  */
-class SeparableField extends BaseField
-{
-    /** @var string */
-    public const SETTING_KEY = 'field_separation_enabled';
+class SeparableField extends BaseField {
+	/** @var string */
+	public const SETTING_KEY = 'field_separation_enabled';
 
-    /**
-     * @inheritdoc
-     * @return BaseValue[]
-     */
-    public function getColumns()
-    {
-        if (!$this->isSeparationEnabled()) {
-            return parent::getColumns();
-        }
+	/**
+	 * @inheritdoc
+	 * @return BaseValue[]
+	 */
+	public function getColumns() {
+		if ( ! $this->isSeparationEnabled() ) {
+			return parent::getColumns();
+		}
 
-        return $this->wrap($this->getSeparatedColumns(), true);
-    }
+		return $this->wrap( $this->getSeparatedColumns(), true );
+	}
 
 	/**
 	 * @inheritdoc
@@ -46,69 +44,100 @@ class SeparableField extends BaseField
 			return $this->wrap( $fields );
 		}
 
-		$value = $this->filter_value( implode( "\n", array_filter( $fields ) ), $entry );
+		$value = $this->filter_value( implode( $this->getCombinedFieldsSeparator(), array_filter( $fields ) ), $entry );
 
 		return $this->wrap( [ $value ] );
 	}
 
-    /**
-     * Get the separated fields to go along with the columns.
-     * @param mixed[] $entry The entry object.
-     * @return mixed[] The field values.
-     */
-    protected function getSeparatedFields($entry)
-    {
-        $entry_keys = array_keys($this->getSeparatedColumns());
+	/**
+	 * Returns the separator used to combine subfield values when separation is disabled.
+	 *
+	 * @since TODO
+	 *
+	 * @return string The separator string.
+	 */
+	protected function getCombinedFieldsSeparator(): string {
+		$glue = gf_apply_filters(
+			[
+				'gfexcel_field_separated_separator',
+				$this->field->get_input_type(),
+				$this->field->formId,
+				$this->field->id,
+			],
+			"\n",
+			$this->field
+		);
 
-        return array_map(function ($key) use ($entry) {
-            return $this->getFieldValue($entry, $key);
-        }, $entry_keys);
-    }
+		$glue = gf_apply_filters(
+			[
+				'gfexcel_field_' . $this->field->get_input_type() . '_separator',
+				$this->field->formId,
+				$this->field->id,
+			],
+			$glue,
+			$this->field
+		);
 
-    /**
-     * Whether we should use separated fields.
-     * @return bool Whether we should use separated fields.
-     */
-    protected function isSeparationEnabled()
-    {
-	    $plugin = GravityExportAddon::get_instance();
+		return (string) $glue;
+	}
 
-	    return gf_apply_filters( [
-		    'gfexcel_field_separated',
-		    $this->field->get_input_type(),
-		    $this->field->formId,
-		    $this->field->id,
-	    ], (bool) $plugin->get_plugin_setting( self::SETTING_KEY ), $this->field );
-    }
+	/**
+	 * Get the separated fields to go along with the columns.
+	 *
+	 * @param mixed[] $entry The entry object.
+	 *
+	 * @return mixed[] The field values.
+	 */
+	protected function getSeparatedFields( $entry ) {
+		$entry_keys = array_keys( $this->getSeparatedColumns() );
 
-    /**
-     * Get the column names for every active subfield.
-     * @return array
-     */
-    protected function getSeparatedColumns()
-    {
-        return array_reduce($this->getVisibleSubfields(), function ($carry, $field) {
-            $field_id = (string) $field['id'];
-            $carry[$field_id] = gf_apply_filters([
-                'gfexcel_field_label',
-                $this->field->get_input_type(),
-                $this->field->formId,
-                $this->field->id
-            ], $this->getSubLabel($field), $this->field);
-            return $carry;
-        }, []);
-    }
+		return array_map( function ( $key ) use ( $entry ) {
+			return $this->getFieldValue( $entry, $key );
+		}, $entry_keys );
+	}
 
-    /**
-     * Retrieve all active subfields for this field.
-     * @return array
-     */
-    protected function getVisibleSubfields()
-    {
-        return array_filter((array) $this->field->get_entry_inputs(), function ($subfield) {
-            return ! isset( $subfield['isHidden'] ) || ! $subfield['isHidden'];
-        });
-    }
+	/**
+	 * Whether we should use separated fields.
+	 * @return bool Whether we should use separated fields.
+	 */
+	protected function isSeparationEnabled() {
+		$plugin = GravityExportAddon::get_instance();
+
+		return gf_apply_filters( [
+			'gfexcel_field_separated',
+			$this->field->get_input_type(),
+			$this->field->formId,
+			$this->field->id,
+		], (bool) $plugin->get_plugin_setting( self::SETTING_KEY ), $this->field );
+	}
+
+	/**
+	 * Get the column names for every active subfield.
+	 * @return array
+	 */
+	protected function getSeparatedColumns() {
+		return array_reduce( $this->getVisibleSubfields(), function ( $carry, $field ) {
+			$field_id           = (string) $field['id'];
+			$carry[ $field_id ] = gf_apply_filters( [
+				'gfexcel_field_label',
+				$this->field->get_input_type(),
+				$this->field->formId,
+				$this->field->id
+			], $this->getSubLabel( $field ), $this->field );
+
+			return $carry;
+		}, [] );
+	}
+
+	/**
+	 * Retrieve all active subfields for this field.
+	 * @return array
+	 */
+	protected function getVisibleSubfields() {
+		return array_filter( (array) $this->field->get_entry_inputs(), function ( $subfield ) {
+			return ! isset( $subfield['isHidden'] ) || ! $subfield['isHidden'];
+		} );
+	}
 
 	/**
 	 * Get the label for a subfield.

--- a/src/GravityForms/Field/SortFields.php
+++ b/src/GravityForms/Field/SortFields.php
@@ -65,7 +65,39 @@ class SortFields extends Base {
 	 * @since 2.0.0
 	 */
 	public function markup(): string {
-		$html = [ '<div class="gk-gravityexport-sort-fields">' ];
+		$search_id          = $this->name . '-search';
+		$search_placeholder = esc_attr__( 'Filter fields…', 'gk-gravityexport-lite' );
+		$search_label       = esc_html__( 'Filter fields', 'gk-gravityexport-lite' );
+
+		$status_id = $this->name . '-search-status';
+
+		$html = [
+			'<div class="gk-gravityexport-sort-fields">',
+			sprintf(
+				'<div class="gk-gravityexport-sort-fields__search">
+					<label for="%s" class="screen-reader-text">%s</label>
+					<div class="gk-gravityexport-sort-fields__search-input-wrapper">
+						<input type="search" id="%s" class="gk-gravityexport-sort-fields__search-input" placeholder="%s" autocomplete="off" aria-controls="%s %s" aria-describedby="%s">
+						<span class="gk-gravityexport-sort-fields__search-icon" aria-hidden="true">
+							<i class="fa fa-search"></i>
+						</span>
+					</div>
+					<div id="%s" class="gk-gravityexport-sort-fields__search-status" role="status" aria-live="polite">
+						<span class="gk-gravityexport-sort-fields__search-status-text"></span>
+						<a href="#" class="gk-gravityexport-sort-fields__clear-search">%s</a>
+					</div>
+				</div>',
+				esc_attr( $search_id ),
+				$search_label,
+				esc_attr( $search_id ),
+				$search_placeholder,
+				esc_attr( $this->name . '-enabled' ),
+				esc_attr( $this->name . '-disabled' ),
+				esc_attr( $status_id ),
+				esc_attr( $status_id ),
+				esc_html__( 'Clear search', 'gk-gravityexport-lite' )
+			),
+		];
 
 		foreach ( $this->sections as $section => [$heading, $target] ) {
 			$html[] = sprintf( '<div><p><strong>%s</strong></p>', $heading );
@@ -80,10 +112,12 @@ class SortFields extends Base {
 			);
 
 			$html[] = sprintf(
-				'<ul id="%s" %s data-send-to="%s" class="fields-select">%s</ul>',
+				'<ul id="%s" %s data-send-to="%s" data-list-label="%s" class="fields-select" role="listbox" aria-label="%s">%s</ul>',
 				$this->name . '-' . $section,
 				implode( ' ', $this->get_attributes() ),
 				$this->name . '-' . $target,
+				esc_attr( wp_strip_all_tags( $heading ) ),
+				esc_attr( wp_strip_all_tags( $heading ) ),
 				implode( "\n", array_map( \Closure::fromCallable( [
 					$this,
 					'choiceHtml'
@@ -106,16 +140,21 @@ class SortFields extends Base {
 	 * @return string The HTML for this choice.
 	 */
 	protected function choiceHtml( \GF_Field $choice ): string {
+		$label = $choice->get_field_label( ! $this->use_admin_labels, '' );
+
 		return sprintf(
-			'<li data-value="%s">
-                <div class="field"><i class="fa fa-bars"></i> <span>%s</span></div>
-                <div class="move">
-                    <i class="fa fa-arrow-right"></i>
-                    <i class="fa fa-close"></i>
+			'<li data-value="%s" role="option" aria-label="%s">
+                <div class="field"><i class="fa fa-bars" aria-hidden="true"></i> <span>%s</span></div>
+                <div class="move" role="button" tabindex="0" aria-label="%s">
+                    <i class="fa fa-arrow-right" aria-hidden="true"></i>
+                    <i class="fa fa-close" aria-hidden="true"></i>
                 </div>
             </li>',
 			$choice->id,
-			$choice->get_field_label( !$this->use_admin_labels, '' )
+			esc_attr( $label ),
+			$label,
+			/* translators: %s: field label */
+			esc_attr( sprintf( __( 'Move %s', 'gk-gravityexport-lite' ), $label ) )
 		);
 	}
 


### PR DESCRIPTION
* Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.
* Enhancement: Accessibility support for the field selector:
  - Screen reader announcements when fields are moved between lists;
  - Keyboard navigation with Enter/Space to move fields and Escape to clear search;
  - Visible focus indicators for keyboard users;
  - Proper ARIA labels on all interactive elements.
* Enhancement: RTL (right-to-left) language support for the field selector interface.
* Enhancement: Added filter hooks change the separator used to combine complex fields, like Name and Address.
* Fixed: PHP warning when field names are used as regex patterns without proper delimiters.

__Developer Updates:__

* Added: `gfexcel_field_separated_separator` filter to change the default separator for all combined subfields (default: newline).
* Added: `gfexcel_field_{field_type}_separator` filter (e.g., `gfexcel_field_name_separator`) to change the separator for a specific field type.


💾 [Build file](https://www.dropbox.com/scl/fi/i5au3ol8ovmdks9gewnn1/gf-entries-in-excel-2.5.0-64cde99.zip?rlkey=8q6mzsky90ir2gl4prriwy24t&dl=1) (64cde99).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search field to quickly locate fields when configuring exports
  * Keyboard navigation support for moving fields between enabled/disabled lists
  * Customizable field separators through new filter hooks

* **Enhancements**
  * Improved accessibility with screen reader support and visible focus indicators
  * Added RTL language support for field selector interface

* **Bug Fixes**
  * Fixed PHP warning when field names used as regex patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->