### PR TITLE
Fix Stable tag pointing to 2.4.2 instead of 2.5.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Gravity Forms, GravityForms, Excel, Export, Entries
 Requires at least: 4.0
 Requires PHP: 7.2
 Tested up to: 6.9.0
-Stable tag: 2.4.2
+Stable tag: 2.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary

- `readme.txt` had `Stable tag: 2.4.2` even though 2.5.0 was released
- WordPress.org uses this field to determine which SVN tag to serve as the download
- This explains why the changelog showed 2.5.0 but the download was still 2.4.2

## Next step

After merging, the deploy workflow needs to be re-triggered to push the corrected `readme.txt` to SVN trunk. Easiest option: delete and re-publish the 2.5.0 GitHub release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 2.5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->