### PR TITLE
Release 2.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "league/container": "^3.3",
         "phpoffice/phpspreadsheet": "1.19.*",
         "symfony/polyfill-iconv": "^1.31",
-        "symfony/polyfill-mbstring": "^1.31"
+        "symfony/polyfill-mbstring": "^1.31",
+        "symfony/polyfill-php80": "^1.31"
     },
     "autoload": {
         "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58df2b4f275743669dbb431e371cd70b",
+    "content-hash": "45cb344b12989c90614471348b2807e5",
     "packages": [
         {
             "name": "ezyang/htmlpurifier",
@@ -894,6 +894,86 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -3368,86 +3448,6 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
             "name": "symfony/process",
             "version": "v5.4.44",
             "source": {
@@ -3879,9 +3879,9 @@
         "ext-json": "*",
         "php": "^7.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.2.34"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Gravity Forms, GravityForms, Excel, Export, Entries
 Requires at least: 4.0
 Requires PHP: 7.2
 Tested up to: 6.9.4
-Stable tag: 2.5.0
+Stable tag: 2.6.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -260,6 +260,9 @@ You can hide a row by adding a hook. Checkout this example:
 
 * Added: `gk/gravityexport/fields/additional-meta-fields` filter to customize the additional meta fields available for export.
 * Fixed: "Date Updated" values were displayed in GMT instead of the local time.
+
+__Developer Updates:__
+* Please note that the `gravitykit/gravityexport-lite` package on Packagist has been abandoned and is no longer maintained.
 
 = 2.5.0 on January 29, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,11 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= develop =
+
+* Fixed: "Date Updated" values were displayed in GMT instead of the local time.
+* Added: A filter hook to customize the additional meta fields available for export.
+
 = 2.5.0 on January 29, 2026 =
 
 * Added: A search field for the Enabled and Disabled Fields lists on the form settings page. Quickly find fields by name when configuring exports for forms with many fields.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Gravity Forms, GravityForms, Excel, Export, Entries
 Requires at least: 4.0
 Requires PHP: 7.2
 Tested up to: 6.9.0
-Stable tag: 2.4.2
+Stable tag: 2.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -258,7 +258,7 @@ You can hide a row by adding a hook. Checkout this example:
 
 = 2.6.0 on March 26, 2026 =
 
-* Added: A filter hook to customize the additional meta fields available for export.
+* Added: `gk/gravityexport/fields/additional-meta-fields` filter to customize the additional meta fields available for export.
 * Fixed: "Date Updated" values were displayed in GMT instead of the local time.
 
 = 2.5.0 on January 29, 2026 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.gravitykit.com/extensions/gravityexport/?utm_source=plu
 Tags: Gravity Forms, GravityForms, Excel, Export, Entries
 Requires at least: 4.0
 Requires PHP: 7.2
-Tested up to: 6.9.0
+Tested up to: 6.9.4
 Stable tag: 2.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -256,10 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= develop =
+= 2.6.0 on March 26, 2026 =
 
-* Fixed: "Date Updated" values were displayed in GMT instead of the local time.
 * Added: A filter hook to customize the additional meta fields available for export.
+* Fixed: "Date Updated" values were displayed in GMT instead of the local time.
 
 = 2.5.0 on January 29, 2026 =
 

--- a/src/Field/AbstractField.php
+++ b/src/Field/AbstractField.php
@@ -131,7 +131,7 @@ abstract class AbstractField implements FieldInterface {
 	 * @return mixed The value of the field.
 	 */
 	protected function getGFieldValue( $entry, $input_id ) {
-		if ( in_array( $input_id, [ 'date_created', 'payment_date' ] ) ) {
+		if ( in_array( $input_id, [ 'date_created', 'date_updated', 'payment_date' ] ) ) {
 			// Return empty string if the date value is not set to avoid falling back to current time.
 			if ( empty( $entry[ $input_id ] ) ) {
 				return '';

--- a/src/Field/MetaField.php
+++ b/src/Field/MetaField.php
@@ -10,6 +10,7 @@ use GFExcel\Values\BaseValue;
 class MetaField extends BaseField implements RowsInterface {
 	/**
 	 * List of internal subfields.
+	 *
 	 * @var string[]
 	 */
 	protected $subfields = [
@@ -59,7 +60,7 @@ class MetaField extends BaseField implements RowsInterface {
 		if ( in_array( $this->field->id, [
 			'id',
 			'form_id',
-			'created_by'
+			'created_by',
 		] ) ) {
 			return BaseValue::TYPE_NUMERIC;
 		}
@@ -70,6 +71,7 @@ class MetaField extends BaseField implements RowsInterface {
 
 	/**
 	 * Returns a list of classnames map for meta fields. 'field' => 'FQN'
+	 *
 	 * @return string[]
 	 */
 	private function getSubFieldsClasses() {
@@ -80,6 +82,7 @@ class MetaField extends BaseField implements RowsInterface {
 
 	/**
 	 * Get a subfield instance if available.
+	 *
 	 * @return FieldInterface|null
 	 */
 	private function getSubField() {

--- a/src/GFExcelOutput.php
+++ b/src/GFExcelOutput.php
@@ -277,6 +277,10 @@ class GFExcelOutput
 			    $this->feed_id
 		    );
 
+			// Clear the meta cache for late meta field registration.
+		    global $_entry_meta;
+		    unset( $_entry_meta[ $this->form_id ] );
+
 		    // prevent a multi-k database query to build up the array.
 		    $loop = true;
 		    while ( $loop ) {

--- a/src/Migration/Migration/SingleFeedMigration.php
+++ b/src/Migration/Migration/SingleFeedMigration.php
@@ -61,15 +61,29 @@ final class SingleFeedMigration extends Migration {
 			$this->updateForms( $form_ids );
 		}
 
-		if ($this->manager) {
+		$message = sprintf(
+			esc_html__( 'The settings for %s 2.0 were migrated successfully.', 'gk-gravityexport-lite' ),
+			defined( 'GK_GRAVITYEXPORT_PLUGIN_VERSION' ) ? 'GravityExport' : 'GravityExport Lite'
+		);
+
+		if ( class_exists( 'GravityKitFoundation' ) ) {
+			\GravityKitFoundation::notices()->add_stored( [
+				'namespace'    => 'gk-gravityexport',
+				'slug'         => 'migration-2-0-0',
+				'message'      => $message,
+				'severity'     => 'success',
+				'dismissible'  => true,
+				'screens'      => [ 'dashboard' ],
+				'context'      => 'all',
+				'capabilities' => [ 'manage_options' ],
+			] );
+		} elseif ( $this->manager ) {
 			$notifications = $this->manager->getNotificationManager();
+
 			try {
 				$notifications->storeNotification( new Notification(
 					'gk/gravity-export-migration/2.0.0',
-					sprintf(
-						esc_html__( 'The settings for %s 2.0 were migrated successfully.', 'gk-gravityexport-lite' ),
-						defined( 'GK_GRAVITYEXPORT_PLUGIN_VERSION' ) ? 'GravityExport' : 'GravityExport Lite'
-					),
+					$message,
 					Notification::TYPE_SUCCESS
 				) );
 			} catch ( NotificationException|NotificationManagerException $e ) {

--- a/src/Renderer/PHPExcelRenderer.php
+++ b/src/Renderer/PHPExcelRenderer.php
@@ -105,9 +105,11 @@ class PHPExcelRenderer extends AbstractPHPExcelRenderer
             ->setCreator(GFExcel::$name)
             ->setLastModifiedBy(GFExcel::$name);
 
-        $this->setTitle($this->form['title'])
-            ->setSubject($this->form['title'])
-            ->setDescription($this->form['description']);
+        $title = $this->form['title'] ?? '';
+
+        $this->setTitle($title)
+            ->setSubject($title)
+            ->setDescription($this->form['description'] ?? '');
 
         $this->extension = GFExcel::getFileExtension($this->form);
 

--- a/src/Repository/FieldsRepository.php
+++ b/src/Repository/FieldsRepository.php
@@ -80,18 +80,67 @@ class FieldsRepository {
 		}
 
 		if ( empty( $this->meta_fields ) ) {
+			/**
+			 * Modifies the additional meta fields added to the export.
+			 *
+			 * @since $ver$
+			 *
+			 * @param array $additional_fields Associative array of field ID to label. Default `[ 'date_updated' => 'Date Updated' ]`.
+			 * @param int   $form_id           The current form ID.
+			 */
+			$additional_fields = (array) gf_apply_filters(
+				[
+					'gk/gravityexport/fields/additional-meta-fields',
+					$this->form['id'] ?? 0,
+				],
+				[
+					'date_updated' => __( 'Date Updated', 'gk-gravityexport-lite' ),
+				],
+				$this->form['id'] ?? 0
+			);
 
-			add_filter( 'gform_export_fields', function ( $form ) {
-				array_push( $form['fields'], array( 'id' => 'date_updated', 'label' => __( 'Date Updated', 'gk-gravityexport-lite' ) ) );
+			add_filter( 'gform_export_fields', $cb = function ( $form ) use ( $additional_fields ) {
+				foreach ($additional_fields as $id => $label) {
+					$form['fields'][] = compact( 'id', 'label' );
+				}
+
 				return $form;
 			} );
 
-			$form              = GFExport::add_default_export_fields( [ 'id' => $this->form['id'] ?? 0, 'fields' => [] ] );
-			$this->meta_fields = array_reduce( $form['fields'], function ( $carry, GF_Field $field ) {
+			$current_form_id = (int) ( $this->form['id'] ?? 0 );
+			add_filter( 'gform_entry_meta', static function ( array $entry_meta, $form_id ) use ( $additional_fields, $current_form_id ): array {
+				if ( (int) $form_id !== $current_form_id ) {
+					return $entry_meta;
+				}
+
+				foreach ( $additional_fields as $id => $label ) {
+					if ( isset( $entry_meta[ $id ] ) ) {
+						continue;
+					}
+
+					$entry_meta[ $id ] = [
+						'label'             => $label,
+						'is_numeric'        => false,
+						'is_default_column' => false,
+					];
+				}
+
+				return $entry_meta;
+			}, 10, 2 );
+
+			$form              = GFExport::add_default_export_fields( [
+				'id'     => $this->form['id'] ?? 0,
+				'fields' => []
+			] );
+
+			remove_filter( 'gform_export_fields', $cb );
+
+			$this->meta_fields = array_reduce( $form['fields'], static function ( array $carry, GF_Field $field ) {
 				$field->type         = 'meta';
 				$carry[ $field->id ] = $field;
+
 				return $carry;
-			} );
+			}, [] );
 		}
 
 		return $use_metadata;
@@ -216,10 +265,10 @@ class FieldsRepository {
 				'value' => 'date_created',
 				'label' => __( 'Entry Date', 'gk-gravityexport-lite' ),
 			],
-            [
-                'value' => 'date_updated',
-                'label' => __( 'Date Updated', 'gk-gravityexport-lite' ),
-            ],
+			[
+				'value' => 'date_updated',
+				'label' => __( 'Date Updated', 'gk-gravityexport-lite' ),
+			],
 			[
 				'value' => 'id',
 				'label' => __( 'Entry ID', 'gk-gravityexport-lite' ),

--- a/src/Repository/FieldsRepository.php
+++ b/src/Repository/FieldsRepository.php
@@ -83,7 +83,7 @@ class FieldsRepository {
 			/**
 			 * Modifies the additional meta fields added to the export.
 			 *
-			 * @since $ver$
+			 * @since 2.6.0
 			 *
 			 * @param array $additional_fields Associative array of field ID to label. Default `[ 'date_updated' => 'Date Updated' ]`.
 			 * @param int   $form_id           The current form ID.

--- a/src/Transformer/Transformer.php
+++ b/src/Transformer/Transformer.php
@@ -17,20 +17,20 @@ class Transformer {
 	 * @var array
 	 */
 	protected $fields = [
-		'calculation'   => 'GFExcel\Field\ProductField',
-		'checkbox'      => 'GFExcel\Field\CheckboxField',
-		'date'          => 'GFExcel\Field\DateField',
-		'fileupload'    => 'GFExcel\Field\FileUploadField',
-		'form'          => 'GFExcel\Field\NestedFormField',
-		'likert'        => 'GFExcel\Field\SurveyLikertField',
-		'list'          => 'GFExcel\Field\ListField',
-		'meta'          => 'GFExcel\Field\MetaField',
-		'name'          => 'GFExcel\Field\SeparableField',
-		'notes'         => 'GFExcel\Field\NotesField',
-		'number'        => 'GFExcel\Field\NumberField',
-		'repeater'      => 'GFExcel\Field\RepeaterField',
-		'singleproduct' => 'GFExcel\Field\ProductField',
-		'section'       => 'GFExcel\Field\SectionField',
+		'calculation'              => 'GFExcel\Field\ProductField',
+		'checkbox'                 => 'GFExcel\Field\CheckboxField',
+		'date'                     => 'GFExcel\Field\DateField',
+		'fileupload'               => 'GFExcel\Field\FileUploadField',
+		'form'                     => 'GFExcel\Field\NestedFormField',
+		'likert'                   => 'GFExcel\Field\SurveyLikertField',
+		'list'                     => 'GFExcel\Field\ListField',
+		'meta'                     => 'GFExcel\Field\MetaField',
+		'name'                     => 'GFExcel\Field\SeparableField',
+		'notes'                    => 'GFExcel\Field\NotesField',
+		'number'                   => 'GFExcel\Field\NumberField',
+		'repeater'                 => 'GFExcel\Field\RepeaterField',
+		'section'                  => 'GFExcel\Field\SectionField',
+		'singleproduct'            => 'GFExcel\Field\ProductField',
 	];
 
 	/**


### PR DESCRIPTION
* Added: `gk/gravityexport/fields/additional-meta-fields` filter to customize the additional meta fields available for export.
* Fixed: "Date Updated" values were displayed in GMT instead of the local time.

__Developer Updates:__
* Please note that the `gravitykit/gravityexport-lite` package on Packagist has been abandoned and is no longer maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a filter hook to customize additional metadata fields during export.

* **Bug Fixes**
  * Exported "Date Updated" now shows local time instead of GMT.

* **Chores**
  * Added Symfony polyfill for PHP 8.0 to dependencies.

* **Documentation**
  * Updated tested up to to 6.9.4, bumped stable tag to 2.6.0, added 2.6.0 changelog entry, and marked a legacy Packagist package as abandoned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->