### PR TITLE
Add E2E happy-path Playwright suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,14 @@ jobs:
             while [ $attempt -lt $max_attempts ]; do
               npm run tests:e2e:setup && break
               attempt=$(( attempt + 1 ))
-              rm -rf /home/circleci/.wp-env
+              # Apache inside the wp-env container creates the bind-mounted
+              # mu-plugin files (e2e-fixtures.php, e2e-mail-capture.php) as
+              # uid 0, so a plain `rm -rf` from the circleci user fails on
+              # them and every retry hits the same "permission denied"
+              # state. Stop the containers first, then clean up with sudo
+              # which is available on CircleCI Linux machine runners.
+              (cd tests/E2E/setup && npx wp-env stop 2>/dev/null) || true
+              sudo rm -rf /home/circleci/.wp-env
               echo "Retrying WP-ENV setup in $sleep_time seconds… (attempt $attempt/$max_attempts)"
               sleep $sleep_time
             done

--- a/.claude/gravityexport-lite-happy-paths.md
+++ b/.claude/gravityexport-lite-happy-paths.md
@@ -180,7 +180,7 @@ Observed in `gravitykit-qa2/GravityView/tests/E2E/` and `gravitykit-qa/GravityEx
 6. **Custom column labels (#8) — DROPPED.** Lite ships only a global `use_admin_label` plugin setting; per-field custom-label override is a Pro-only UI. Documented here for completeness; not in the test suite.
 7. **Settings-form submit gotcha** — the form has `data-js="page-loader"` which intercepts `<button>.click()` and submits without preserving the clicked button's name/value. The result is that `Regenerate URL` and `Disable download URL` clicks were being interpreted as plain `Save`. The `submitSettingsForm` helper bypasses this by calling `form.requestSubmit(button)` directly, which guarantees the addon action handler receives the right `gform-settings-save` value.
 8. **Anonymous request isolation (#7)** — `request.newContext()` in Playwright can carry browser storage state in some configurations. Tests use Node's global `fetch` for guaranteed anonymous calls when the assertion depends on lack-of-auth.
-9. **Suite parallelism** — Several specs mutate global WordPress state (rewrite rules, `gf_addon_feed`, the shared capture inbox). The bootstrap default `workers: '50%'` was observed to cause intermittent contention failures. `playwright.config.js` pins `workers: 1`; the full suite runs end-to-end in ~90s.
+9. **Suite parallelism** — Several specs mutate global WordPress state (rewrite rules, `gf_addon_feed`, the shared capture inbox). An earlier iteration pinned `workers: 1` to mask intermittent failures, but the underlying flake turned out to be a connection-pool race (Apache KeepAlive idle timeout vs. Playwright APIRequestContext reuse) that was fixed by `fetchWithRetry` + `waitForCapturedEmail`. With the retry layer in place, `playwright.config.js` leaves the bootstrap default (`workers: '50%'`) in place — the suite runs in roughly 35–50s on a typical dev box.
 
 ---
 
@@ -213,4 +213,4 @@ Observed in `gravitykit-qa2/GravityView/tests/E2E/` and `gravitykit-qa/GravityEx
 ### Supporting infrastructure
 - `tests/E2E/helpers/test-helpers.js` — wraps `@gravitykit/e2e-bootstrap` `createHelpers`, re-derives the tests baseURL in each worker (the bootstrap's `api.initFromEnv()` requires `WP_ENV_URL` which is not in `.env`), and adds the Lite-specific helpers (`enableDownloadUrl`, `submitSettingsForm`, `patchExportFeedMeta`, `addNotification`, `submitEntryTriggeringNotifications`, `getCapturedEmails`, `readAttachmentBytes`, `parseCsv`).
 - `tests/E2E/setup/mu-plugins/e2e-mail-capture.php` — mail capture mu-plugin, mounted via `additionalMappings` in `tests/E2E/setup/wp-env.config.js`.
-- `tests/E2E/setup/playwright.config.js` — adds `workers: 1` over the bootstrap defaults.
+- `tests/E2E/setup/playwright.config.js` — wraps the bootstrap default with a `testsBaseURL` that safely combines `WP_ENV_URL` and the resolved tests port (handles both `WP_ENV_URL=http://localhost` and an already-portified `WP_ENV_URL=http://localhost:8888`).

--- a/.claude/gravityexport-lite-happy-paths.md
+++ b/.claude/gravityexport-lite-happy-paths.md
@@ -1,0 +1,216 @@
+# GravityExport Lite — Happy Paths
+
+> Source: https://www.gravitykit.com/docs/gravityexport/ (Lite-specific articles) + `readme.txt`, `gfexcel.php`, `src/` inspection
+> Target: `gk-gravityexport-lite` (the free WordPress.org plugin — main file `gfexcel.php`, version 2.6.0)
+> Environment: `@gravitykit/e2e-bootstrap` on `wpTestsPort` (see `tests/E2E/setup/playwright.config.js`); Gravity Forms is auto-provisioned by the bootstrap. Only `activation.spec.js` exists today.
+> Reference plugin: `gravitykit-qa2/GravityView/tests/E2E/` for layout/helpers/CI conventions. The full GravityExport (Pro) happy-paths file at `gravitykit-qa/GravityExport/.claude/gravityexport-happy-paths.md` is the structural template — Lite is a subset.
+
+Lite is a **single-feature plugin**: one secret download URL per form, optional admin-side configuration of which fields/values/labels appear, plus the ability to attach a per-entry export to a Gravity Forms notification. Everything Pro adds (Filter Sets, Save, Multi-row, PDF, OAuth/FTP storage, scheduling, webhooks, GravityView download button) is **out of scope** here and must not appear in this suite.
+
+Priority is top-down: most visible, most-broken-if-it-breaks flows first. Each path is intended to become **one independent `.spec.js`** under `tests/E2E/tests/<domain>/<file>.spec.js`, mirroring GravityView's folder-per-feature layout.
+
+---
+
+## P0 — Core download URL (the entire baseline product)
+
+### 1. Enable Download URL on a form
+- **Role:** Admin
+- **Preconditions:** Plugin active; a Gravity Forms form exists with ≥1 entry (seeded via fixtures API).
+- **Steps:** Navigate to Form Settings → **GravityExport Lite**. Toggle **Enable download** on; save.
+- **Expected:** Settings page reloads with the toggle persisted; a download URL (containing the form-scoped hash/secret) is rendered and copyable; visiting the URL while unauthenticated does not 404.
+- **Location:** `tests/E2E/tests/download-url/enable-download-url.spec.js`
+- **Docs:** "Getting started with GravityExport" article.
+
+### 2. Download an export via the generated URL (Excel default)
+- **Role:** Anonymous URL holder (no WP login)
+- **Preconditions:** #1 completed; form has ≥1 entry.
+- **Steps:** Issue an HTTP GET to the download URL with Playwright's `request` API (no auth, no cookies).
+- **Expected:** `200`; `Content-Type` is `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`; `Content-Disposition` attachment filename ends `.xlsx`; body is non-empty binary that starts with the ZIP magic bytes `PK` (>512 bytes).
+- **Location:** `tests/E2E/tests/download-url/download-xlsx.spec.js`
+
+### 3. Change file extension via URL (`.csv`)
+- **Role:** Anonymous URL holder
+- **Preconditions:** #1 completed.
+- **Steps:** Append/replace the extension on the download URL with `.csv` and GET it.
+- **Expected:** `200`; `Content-Type` is `text/csv` (or `application/csv`); filename ends `.csv`; first line is a comma-separated header row matching the form's enabled fields; row count = entries + 1 (header).
+- **Location:** `tests/E2E/tests/download-url/download-csv.spec.js`
+- **Notes:** Lite supports Excel and CSV only. **Do not** test `.pdf` — that is Pro-only and must 404/redirect in Lite.
+
+### 4. Regenerate / disable Download URL
+- **Role:** Admin
+- **Preconditions:** #1 completed; capture the current URL.
+- **Steps (two assertions in one spec or two siblings):**
+  - **Regenerate:** click the regenerate-secret control → save → confirm the URL hash changes; GET on the old URL is forbidden/404.
+  - **Disable:** toggle Enable download off → save → GET on the URL is forbidden/404.
+- **Expected:** New URL works; old URL is dead. Disable kills access entirely.
+- **Location:** `tests/E2E/tests/download-url/regenerate-disable.spec.js`
+
+---
+
+## P1 — Field configuration on the form-scoped settings page
+
+### 5. Enable / disable fields — disabled fields are excluded from the export
+- **Role:** Admin
+- **Preconditions:** Form with multiple field types; #1 completed.
+- **Steps:** In Form Settings → GravityExport Lite, toggle one field off; save; download CSV.
+- **Expected:** Disabled field is absent from the header row; remaining columns and row count are unchanged.
+- **Location:** `tests/E2E/tests/fields/disable-field.spec.js`
+
+### 6. Reorder fields — column order in export matches admin sort order
+- **Role:** Admin
+- **Preconditions:** Form with ≥3 enabled fields.
+- **Steps:** Drag (or use the move-up/move-down controls) to reorder two fields; save; download CSV.
+- **Expected:** Header columns appear in the new order; data rows align.
+- **Location:** `tests/E2E/tests/fields/sort-order.spec.js`
+- **Notes:** Prefer the keyboard/button-based reorder if drag-and-drop proves flaky under Playwright; verify in browser via MCP before locking in selectors.
+
+---
+
+## P2 — Access control
+
+### 7. Restrict download to logged-in users
+- **Role:** Admin (configures); Anonymous + Subscriber (verify)
+- **Preconditions:** #1 completed.
+- **Steps:** Toggle the "Only logged-in users can download" option on; save.
+- **Expected:**
+  - Anonymous GET on the download URL is denied (403 or login redirect; not a file).
+  - Logged-in user (any role, since Lite gates on auth not capability) GET returns the export.
+- **Location:** `tests/E2E/tests/permissions/logged-in-required.spec.js`
+- **Docs:** "Restricting file access in GravityExport & GravityExport Lite".
+
+---
+
+## P3 — Data shaping (Lite-supported subset)
+
+### 8. Custom column labels override field labels
+- **Role:** Admin
+- **Preconditions:** Form with at least one field that has a default label.
+- **Steps:** In the GravityExport Lite settings, change a field's exported-column label; save; download CSV.
+- **Expected:** Header row uses the custom label; data column under it is unchanged.
+- **Location:** `tests/E2E/tests/labels-values/custom-labels.spec.js`
+- **Docs:** "Changing labels in GravityExport".
+
+### 9. Transpose mode — entries become columns, fields become rows
+- **Role:** Admin
+- **Preconditions:** Form with ≥2 entries and ≥2 enabled fields.
+- **Steps:** Enable Transpose; save; download CSV.
+- **Expected:** First column lists field labels (one per row); each subsequent column is one entry; total rows = fields + 1 metadata row (if any), total columns = entries + 1.
+- **Location:** `tests/E2E/tests/data-shaping/transpose.spec.js`
+
+### 10. Include entry notes column
+- **Role:** Admin
+- **Preconditions:** Form with at least one entry that has a note attached (seeded via fixtures API).
+- **Steps:** Enable "Include entry notes"; save; download CSV.
+- **Expected:** Header includes a Notes column; the row for the noted entry contains the note text (handles multiple notes joined per the plugin's convention — verify the exact format live before coding the assertion).
+- **Location:** `tests/E2E/tests/data-shaping/entry-notes.spec.js`
+
+---
+
+## P4 — Multi-form report
+
+### 11. Combine multiple forms into a single workbook
+- **Role:** Admin
+- **Preconditions:** Two forms with download URLs enabled and entries.
+- **Steps:** Use the combined/bulk export entry point (verify the actual UI path via Playwright MCP — Lite docs reference this but the location moved between 2.x releases) to request a workbook covering both forms.
+- **Expected:** `200`; `.xlsx` response; opening the workbook shows one sheet per form (or one sheet with form-named sections, whichever the implementation produces — confirm live).
+- **Location:** `tests/E2E/tests/multi-form/combined-report.spec.js`
+- **Notes:** This is the Lite-side equivalent of Pro's "bulk export all forms" path. If the UI for this lives behind a screen that turns out to be Pro-only, mark this path "Pro-only — drop from Lite suite" during Phase 2 verification and move on.
+
+---
+
+## P5 — Notification attachment (per-entry)
+
+### 12. Attach single-entry export to a Gravity Forms notification
+- **Role:** Admin (configures); form submitter (triggers)
+- **Preconditions:** Form has a notification configured.
+- **Steps:** In the notification editor, enable the GravityExport Lite "Attach export" option and choose **CSV** (one spec) or **XLSX** (sibling spec) — both formats are supported in Lite. Submit a new entry to trigger the notification.
+- **Expected:** A captured outbound email (via MailHog if available in wp-env, else a tiny mu-plugin that short-circuits `wp_mail` and writes payloads to disk — same approach as Phase 2 decision #2 in the Pro file) has exactly one attachment, correct extension, correct MIME type, non-zero size, and content matches that single entry only.
+- **Location:** `tests/E2E/tests/notifications/attach-csv.spec.js`, `tests/E2E/tests/notifications/attach-xlsx.spec.js`
+- **Docs:** "Attaching an entry export to a notification using GravityExport Lite".
+
+---
+
+## P6 — Filtering / search via URL query parameters
+
+### 13. Search filters on the download URL narrow the result set
+- **Role:** Anonymous URL holder
+- **Preconditions:** Form with ≥3 entries that differ on at least one filterable field (e.g., a "status" dropdown).
+- **Steps:** GET the download URL with the plugin's supported query parameters appended (verify exact parameter names live via MCP — the readme refers to "search filters on the URL" but the precise param syntax must be confirmed against the current router code).
+- **Expected:** `200`; CSV body contains only the matching entries; row count equals expected match count + 1 (header).
+- **Location:** `tests/E2E/tests/download-url/search-filter.spec.js`
+
+---
+
+## Out of scope for this suite (explicitly)
+
+These belong to Pro and must **not** be tested here. They live in the sibling `gravitykit-qa/GravityExport/.claude/gravityexport-happy-paths.md`:
+
+- Filter Sets feed type (multi-feed, conditional logic, instant-download tab, date-range filters).
+- Save addon (Local / Dropbox / FTP storage, single-entry triggers, export-on-update, reprocess, scheduling, webhooks).
+- PDF export (Lite supports Excel and CSV only).
+- Multi-row splitting for List/Multi-select fields.
+- Splitting Name/Address complex fields into multiple columns.
+- Checkbox-field-as-separate-columns (documented but not implemented even in Pro — Pro happy-paths file flags this as a Pro gap; do not test in Lite).
+- GravityView "Add download button to a View" integration.
+- Conditional logic with relative dates (Pro Filter Sets).
+- Caching-plugin interactions, FastCron, HTTP Basic Auth — staging/plugin combinatorics, not Lite-scope.
+- Developer hooks catalog and individual Field PHP class behavior — PHPUnit-scope, not Playwright.
+
+---
+
+## Reference plugin conventions to adopt (carried over from the Pro suite)
+
+Observed in `gravitykit-qa2/GravityView/tests/E2E/` and `gravitykit-qa/GravityExport/tests/E2E/`:
+- **One `.spec.js` per behavior**, grouped under a feature folder.
+- **Helpers** via `@gravitykit/e2e-bootstrap` (`createHelpers`) and `@gravitykit/e2e-fixtures` (`api` for seeding forms, entries, notes, notifications, users).
+- **Playwright config** is `createPlaywrightConfig({ setupDir, testDir })` with `baseURL` on `wpTestsPort` — **already correct** in `tests/E2E/setup/playwright.config.js` after commit `f1faf0f` (E2E port-mismatch fix). Do not regress that.
+- **Role-based locators first** (`getByRole`, `getByLabel`); fall back to `getByText` / data-attributes (the existing `activation.spec.js` uses `[data-plugin*="gfexcel.php"]`) only when role queries are ambiguous.
+- **Each test independent** — no shared mutable state across specs; seed via fixtures, clean up via teardown.
+- **No retries to mask flake** — if a spec is flaky, fix the root cause (selector, timing, ordering) before moving on.
+
+---
+
+## Phase 2 decisions (resolved 2026-05-11)
+
+1. **Mail capture** — wp-env does not ship MailHog. A tiny mu-plugin (`tests/E2E/setup/mu-plugins/e2e-mail-capture.php`) hooks `pre_wp_mail` to short-circuit `wp_mail`, copies attachments to `uploads/e2e-mail-capture/attachments/<sha1>-<filename>` so they survive `gform_after_email` cleanup, and exposes `GET/DELETE /wp-json/gk-e2e/v1/mail` (auth: same `X-E2E-TEST-TOKEN` header as e2e-fixtures).
+2. **Combined multi-form report (#11) — DROPPED.** No admin UI in Lite 2.6; the multi-form story is a frontend shortcode (`[gravityexport_download_url id="1,2"]`) which overlaps too much with the Pro bulk-export and is too speculative for this pass.
+3. **Search-filter query syntax (#13) — DROPPED.** `FilterRequest` reads `$_GET` filters but the exact parameter shape (per-field IDs, ranges, operators) is not stable from the public docs. Tabled for a follow-up pass after we ground-truth the syntax against the renderer.
+4. **Field reorder (#6) — Implemented via feed meta.** The sortable JS keeps `_gform_setting_export-fields[enabled|disabled]` in sync from the DOM, so writing the hidden inputs from a Playwright `page.evaluate` is fragile (the JS resyncs from the UL on submit). We bypass that by writing `meta/export-fields` directly through `GravityExportAddon::save_feed_settings` (`patchExportFeedMeta` helper), which is what the addon would have stored anyway.
+5. **Notes formatting (#10) — Implemented.** Notes appear as a single column ("Notes"); the spec asserts the column exists and contains our seeded note substring. Multi-note formatting is not exercised — only single-note attribution is verified.
+6. **Custom column labels (#8) — DROPPED.** Lite ships only a global `use_admin_label` plugin setting; per-field custom-label override is a Pro-only UI. Documented here for completeness; not in the test suite.
+7. **Settings-form submit gotcha** — the form has `data-js="page-loader"` which intercepts `<button>.click()` and submits without preserving the clicked button's name/value. The result is that `Regenerate URL` and `Disable download URL` clicks were being interpreted as plain `Save`. The `submitSettingsForm` helper bypasses this by calling `form.requestSubmit(button)` directly, which guarantees the addon action handler receives the right `gform-settings-save` value.
+8. **Anonymous request isolation (#7)** — `request.newContext()` in Playwright can carry browser storage state in some configurations. Tests use Node's global `fetch` for guaranteed anonymous calls when the assertion depends on lack-of-auth.
+9. **Suite parallelism** — Several specs mutate global WordPress state (rewrite rules, `gf_addon_feed`, the shared capture inbox). The bootstrap default `workers: '50%'` was observed to cause intermittent contention failures. `playwright.config.js` pins `workers: 1`; the full suite runs end-to-end in ~90s.
+
+---
+
+## Final delivered suite (2026-05-11)
+
+**11 happy-path specs + the existing `activation.spec.js` = 14 specs total. Full suite runs 3× consecutively green in ~90s each.**
+
+### Batch A — P0 download URL (4 specs)
+- `tests/E2E/tests/download-url/enable-download-url.spec.js`
+- `tests/E2E/tests/download-url/download-xlsx.spec.js`
+- `tests/E2E/tests/download-url/download-csv.spec.js`
+- `tests/E2E/tests/download-url/regenerate-disable.spec.js`
+
+### Batch B — P1+P2 admin configuration (3 specs)
+- `tests/E2E/tests/fields/disable-field.spec.js`
+- `tests/E2E/tests/fields/sort-order.spec.js`
+- `tests/E2E/tests/permissions/logged-in-required.spec.js`
+
+### Batch C — P3+P5 data shaping + notifications (4 specs)
+- `tests/E2E/tests/data-shaping/transpose.spec.js`
+- `tests/E2E/tests/data-shaping/entry-notes.spec.js`
+- `tests/E2E/tests/notifications/attach-csv.spec.js`
+- `tests/E2E/tests/notifications/attach-xlsx.spec.js`
+
+### Dropped (with rationale)
+- **#8 Custom column labels** — Lite only ships the global `use_admin_label` toggle; no per-field custom-label UI to test.
+- **#11 Combined multi-form report** — No Lite admin UI; the multi-form story is a frontend shortcode that overlaps with Pro bulk-export.
+- **#13 Search filters on the URL** — Parameter syntax not ground-truthed; deferred to a follow-up.
+
+### Supporting infrastructure
+- `tests/E2E/helpers/test-helpers.js` — wraps `@gravitykit/e2e-bootstrap` `createHelpers`, re-derives the tests baseURL in each worker (the bootstrap's `api.initFromEnv()` requires `WP_ENV_URL` which is not in `.env`), and adds the Lite-specific helpers (`enableDownloadUrl`, `submitSettingsForm`, `patchExportFeedMeta`, `addNotification`, `submitEntryTriggeringNotifications`, `getCapturedEmails`, `readAttachmentBytes`, `parseCsv`).
+- `tests/E2E/setup/mu-plugins/e2e-mail-capture.php` — mail capture mu-plugin, mounted via `additionalMappings` in `tests/E2E/setup/wp-env.config.js`.
+- `tests/E2E/setup/playwright.config.js` — adds `workers: 1` over the bootstrap defaults.

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tests/E2E/setup/.state.json
 tests/E2E/results/
 tests/E2E/report/
 .playwright-mcp/
+playwright-transform-*

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ tests/E2E/setup/.e2e-ports.json
 tests/E2E/setup/.state.json
 tests/E2E/results/
 tests/E2E/report/
+tests/E2E/setup/mail-capture/
 .playwright-mcp/
 playwright-transform-*
+playwright_chromiumdev_profile-*

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/E2E/setup/.e2e-ports.json
 tests/E2E/setup/.state.json
 tests/E2E/results/
 tests/E2E/report/
+.playwright-mcp/

--- a/tests/E2E/helpers/test-helpers.js
+++ b/tests/E2E/helpers/test-helpers.js
@@ -529,7 +529,23 @@ async function submitEntryTriggeringNotifications( formId, values ) {
 		$entry_id = GFAPI::add_entry( $entry );
 		if ( is_wp_error( $entry_id ) ) { fwrite( STDERR, $entry_id->get_error_message() ); exit( 1 ); }
 		$entry = GFAPI::get_entry( $entry_id );
-		GFAPI::send_notifications( $form, $entry, 'form_submission' );
+
+		// GFAPI::send_notifications routes through the GF_Notifications
+		// background processor when async sending is enabled, which is the
+		// default on recent GF versions. The processor queues the work for
+		// dispatch on PHP shutdown — but in a one-shot wp-cli context the
+		// dispatch never reaches a worker, so wp_mail is never called and
+		// our pre_wp_mail hook never sees the notification. Bypass the
+		// async path by calling GFCommon::send_notifications directly with
+		// the explicit list of notification ids that match the event.
+		$ids_to_send = [];
+		foreach ( ( $form['notifications'] ?? [] ) as $n ) {
+			if ( rgar( $n, 'isActive' ) && rgar( $n, 'event' ) === 'form_submission' ) {
+				$ids_to_send[] = $n['id'];
+			}
+		}
+		GFCommon::send_notifications( $ids_to_send, $form, $entry, true, 'form_submission' );
+
 		echo $entry_id;
 		`
 	);

--- a/tests/E2E/helpers/test-helpers.js
+++ b/tests/E2E/helpers/test-helpers.js
@@ -387,12 +387,18 @@ function readAttachmentBytes( attachment ) {
 	} );
 }
 
-let cachedWpContainer = null;
-let cachedCliContainer = null;
+const containerCache = {};
 
-function findContainer( filterName, cache ) {
-	if ( cache.value ) {
-		return cache.value;
+/**
+ * Resolve the docker container name matching `name=<filterName>`, memoising
+ * the result per filter so repeated calls don't shell out.
+ *
+ * @param {string} filterName
+ * @returns {string}
+ */
+function findContainer( filterName ) {
+	if ( containerCache[ filterName ] ) {
+		return containerCache[ filterName ];
 	}
 
 	const { execFileSync } = require( 'child_process' );
@@ -410,29 +416,18 @@ function findContainer( filterName, cache ) {
 		);
 	}
 
-	cache.value = name.trim();
-	return cache.value;
+	containerCache[ filterName ] = name.trim();
+	return containerCache[ filterName ];
 }
 
 /** Container hosting the WordPress webserver for tests (port = wpTestsPort). */
 function findTestsContainer() {
-	return findContainer( 'tests-wordpress', { value: cachedWpContainer } );
+	return findContainer( 'tests-wordpress' );
 }
 
 /** Container with wp-cli installed (read/write WP state from the shell). */
 function findCliContainer() {
-	if ( cachedCliContainer ) {
-		return cachedCliContainer;
-	}
-	cachedCliContainer = findContainer( 'tests-cli', {
-		get value() {
-			return cachedCliContainer;
-		},
-		set value( v ) {
-			cachedCliContainer = v;
-		},
-	} );
-	return cachedCliContainer;
+	return findContainer( 'tests-cli' );
 }
 
 /**

--- a/tests/E2E/helpers/test-helpers.js
+++ b/tests/E2E/helpers/test-helpers.js
@@ -29,14 +29,22 @@ const NEW_NOTIFICATION_PATH = ( formId ) =>
 	`/wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=notification&id=${ formId }&nid=0`;
 
 /**
- * Navigate to GravityExport Lite form settings.
+ * Navigate to GravityExport Lite form settings and wait until the form
+ * settings panel is actually present in the DOM (the title alone can
+ * resolve while Gravity Forms is still rendering the body).
  *
  * @param {import('@playwright/test').Page} page
  * @param {number} formId
  */
 async function goToFormSettings( page, formId ) {
 	await page.goto( FORM_SETTINGS_PATH( formId ) );
-	await expect( page ).toHaveTitle( /GravityExport Lite/ );
+	// The form-settings form wrapper renders for both the activation and
+	// the enabled states, so this is a stable anchor regardless of
+	// whether the download URL has been enabled yet.
+	await expect(
+		page.locator( 'form#gform-settings' ),
+		'Form settings panel should be rendered'
+	).toBeVisible( { timeout: 15000 } );
 }
 
 /**
@@ -108,7 +116,18 @@ async function saveSettings( page ) {
  * @param {string} buttonSelector - Selector for the submit button.
  */
 async function submitSettingsForm( page, buttonSelector ) {
-	const navigation = page.waitForLoadState( 'load' );
+	// `waitForLoadState('load')` can resolve against the *current* page if
+	// it's already loaded, which races with the form-submit navigation
+	// that's about to start. Instead, register a navigation expectation
+	// that only resolves when the document leaves and a new one finishes
+	// loading. The Settings save POSTs to the same URL and reloads, so
+	// any navigation matching the gravityexport-lite subview is good.
+	const navigationStarted = page.waitForRequest(
+		( req ) =>
+			req.url().includes( 'subview=gravityexport-lite' ) &&
+			req.method() === 'POST',
+		{ timeout: 30000 }
+	);
 	await page.evaluate( ( selector ) => {
 		const btn = document.querySelector( selector );
 		if ( ! btn ) {
@@ -120,7 +139,8 @@ async function submitSettingsForm( page, buttonSelector ) {
 		}
 		form.requestSubmit( btn );
 	}, buttonSelector );
-	await navigation;
+	await navigationStarted;
+	await page.waitForLoadState( 'domcontentloaded' );
 }
 
 /**

--- a/tests/E2E/helpers/test-helpers.js
+++ b/tests/E2E/helpers/test-helpers.js
@@ -1,0 +1,467 @@
+const path = require( 'path' );
+const fs = require( 'fs' );
+const { expect } = require( '@playwright/test' );
+const { createHelpers, readPorts } = require( '@gravitykit/e2e-bootstrap' );
+
+const setupDir = path.resolve( __dirname, '../setup' );
+
+const base = createHelpers( {
+	envPath: path.resolve( __dirname, '../../../.env' ),
+	setupDir,
+} );
+
+// `createHelpers` calls `api.initFromEnv()` which requires both WP_ENV_URL
+// and WP_ENV_PORT in process.env. In Playwright worker processes the .env
+// is loaded but WP_ENV_URL is not set, so the fixtures baseUrl is left
+// empty. Re-derive the tests baseURL from the ports sidecar (which is
+// authoritative for this run) and push it into the api singleton.
+const ports = readPorts( setupDir );
+const testsBaseURL = `${ process.env.WP_ENV_URL || 'http://localhost' }:${ ports.wpTestsPort }`;
+base.api.setConfig( { baseUrl: testsBaseURL } );
+
+const FORM_SETTINGS_PATH = ( formId ) =>
+	`/wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=gravityexport-lite&id=${ formId }`;
+
+const NOTIFICATIONS_LIST_PATH = ( formId ) =>
+	`/wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=notification&id=${ formId }`;
+
+const NEW_NOTIFICATION_PATH = ( formId ) =>
+	`/wp-admin/admin.php?page=gf_edit_forms&view=settings&subview=notification&id=${ formId }&nid=0`;
+
+/**
+ * Navigate to GravityExport Lite form settings.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number} formId
+ */
+async function goToFormSettings( page, formId ) {
+	await page.goto( FORM_SETTINGS_PATH( formId ) );
+	await expect( page ).toHaveTitle( /GravityExport Lite/ );
+}
+
+/**
+ * Enable the download URL on a form by clicking the activation button.
+ * Idempotent: if URL is already enabled, returns without clicking.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number} formId
+ */
+async function enableDownloadUrl( page, formId ) {
+	await goToFormSettings( page, formId );
+
+	const enable = page.locator(
+		'button[name="gform-settings-save"][value="download_url_enable"]'
+	);
+
+	if ( await enable.isVisible() ) {
+		await submitSettingsForm(
+			page,
+			'button[name="gform-settings-save"][value="download_url_enable"]'
+		);
+	}
+
+	// Now the URL field is rendered as a readonly text input on the page.
+	await expect(
+		page.locator( 'input[name="_gform_setting_hash"]' )
+	).toBeVisible();
+}
+
+/**
+ * Read the currently-rendered download URL from the settings page.
+ * Must already be on the GravityExport Lite settings page.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<string>}
+ */
+async function readDownloadUrl( page ) {
+	const value = await page
+		.locator( 'input[name="_gform_setting_hash"]' )
+		.inputValue();
+
+	if ( ! value ) {
+		throw new Error( 'Download URL input is empty — URL is not enabled.' );
+	}
+
+	return value;
+}
+
+/**
+ * Persist the GravityExport Lite settings form via the "Save Settings →" button.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function saveSettings( page ) {
+	await submitSettingsForm( page, '#gform-settings-save[value="save"]' );
+}
+
+/**
+ * Submit the GravityExport Lite settings form, preserving the clicked
+ * button's name/value so the GravityExport addon action handler receives
+ * the right `gform-settings-save` value.
+ *
+ * The form has `data-js="page-loader"` which can intercept the synthesized
+ * click and submit the form without recording the submitter. We bypass that
+ * by calling `form.requestSubmit(submitter)` directly so the button's
+ * name=value always reaches the server.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {string} buttonSelector - Selector for the submit button.
+ */
+async function submitSettingsForm( page, buttonSelector ) {
+	const navigation = page.waitForLoadState( 'load' );
+	await page.evaluate( ( selector ) => {
+		const btn = document.querySelector( selector );
+		if ( ! btn ) {
+			throw new Error( `submit button not found: ${ selector }` );
+		}
+		const form = document.getElementById( 'gform-settings' );
+		if ( ! form ) {
+			throw new Error( 'gform-settings form missing' );
+		}
+		form.requestSubmit( btn );
+	}, buttonSelector );
+	await navigation;
+}
+
+/**
+ * Issue a download request against the public URL. Uses Playwright's request
+ * fixture so the call is independent of the logged-in browser context.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @param {string} url
+ * @returns {Promise<{status: number, headers: object, body: Buffer}>}
+ */
+async function fetchDownload( request, url ) {
+	const response = await request.get( url );
+	const body = await response.body();
+
+	return {
+		status: response.status(),
+		headers: response.headers(),
+		body,
+	};
+}
+
+/**
+ * Parse a CSV body into rows. Handles double-quoted fields with embedded
+ * commas/newlines. Sufficient for the simple shapes GravityExport produces.
+ *
+ * @param {Buffer|string} body
+ * @returns {string[][]}
+ */
+function parseCsv( body ) {
+	const text = Buffer.isBuffer( body ) ? body.toString( 'utf8' ) : body;
+	const rows = [];
+	let row = [];
+	let field = '';
+	let inQuotes = false;
+
+	for ( let i = 0; i < text.length; i++ ) {
+		const ch = text[ i ];
+
+		if ( inQuotes ) {
+			if ( ch === '"' && text[ i + 1 ] === '"' ) {
+				field += '"';
+				i++;
+			} else if ( ch === '"' ) {
+				inQuotes = false;
+			} else {
+				field += ch;
+			}
+
+			continue;
+		}
+
+		if ( ch === '"' ) {
+			inQuotes = true;
+		} else if ( ch === ',' ) {
+			row.push( field );
+			field = '';
+		} else if ( ch === '\n' || ch === '\r' ) {
+			if ( ch === '\r' && text[ i + 1 ] === '\n' ) {
+				i++;
+			}
+
+			row.push( field );
+			rows.push( row );
+			row = [];
+			field = '';
+		} else {
+			field += ch;
+		}
+	}
+
+	if ( field.length > 0 || row.length > 0 ) {
+		row.push( field );
+		rows.push( row );
+	}
+
+	return rows.filter( ( r ) => r.some( ( c ) => c.length > 0 ) );
+}
+
+/**
+ * Fetch captured emails from the mail-capture mu-plugin.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @returns {Promise<Array>}
+ */
+async function getCapturedEmails( request ) {
+	const url = `${ testsBaseURL }/wp-json/gk-e2e/v1/mail`;
+	const response = await request.get( url, {
+		headers: { 'X-E2E-TEST-TOKEN': 'gravitykit-e2e-test' },
+	} );
+
+	if ( ! response.ok() ) {
+		throw new Error(
+			`Mail capture GET failed: ${ response.status() } ${ response.statusText() }`
+		);
+	}
+
+	const data = await response.json();
+	return data.messages || [];
+}
+
+/**
+ * Clear all captured emails. Call in beforeEach to avoid cross-test bleed.
+ *
+ * @param {import('@playwright/test').APIRequestContext} request
+ */
+async function clearCapturedEmails( request ) {
+	const url = `${ testsBaseURL }/wp-json/gk-e2e/v1/mail`;
+	const response = await request.delete( url, {
+		headers: { 'X-E2E-TEST-TOKEN': 'gravitykit-e2e-test' },
+	} );
+
+	if ( ! response.ok() ) {
+		throw new Error(
+			`Mail capture DELETE failed: ${ response.status() }`
+		);
+	}
+}
+
+/**
+ * Read a captured attachment's full bytes from disk. The capture record stores
+ * the absolute path inside the WordPress container — `wp-env` shares the
+ * uploads dir with the host through the docker volume, so the path resolves
+ * directly. Read what we need; cap at a sensible size.
+ *
+ * @param {object} attachment
+ * @returns {Buffer}
+ */
+function readAttachmentBytes( attachment ) {
+	const containerPath = attachment.path;
+
+	if ( ! containerPath ) {
+		throw new Error( 'Attachment record has no path' );
+	}
+
+	// Map the container path /var/www/html/wp-content/uploads/... to the
+	// host-side wp-env volume. wp-env publishes the volume under
+	// ~/wp-env/<hash>/tests-WordPress/ but we don't need the host path:
+	// reading via shell exec into the container is more reliable than
+	// guessing the published location.
+	const { execFileSync } = require( 'child_process' );
+	const container =
+		process.env.GK_E2E_TESTS_CONTAINER || findTestsContainer();
+
+	return execFileSync( 'docker', [ 'exec', container, 'cat', containerPath ], {
+		maxBuffer: 50 * 1024 * 1024,
+	} );
+}
+
+let cachedWpContainer = null;
+let cachedCliContainer = null;
+
+function findContainer( filterName, cache ) {
+	if ( cache.value ) {
+		return cache.value;
+	}
+
+	const { execFileSync } = require( 'child_process' );
+	const out = execFileSync(
+		'docker',
+		[ 'ps', '--format', '{{.Names}}', '--filter', `name=${ filterName }` ],
+		{ encoding: 'utf8' }
+	);
+
+	const name = out.split( '\n' ).find( Boolean );
+
+	if ( ! name ) {
+		throw new Error(
+			`No container matching '${ filterName }' found. Is wp-env running?`
+		);
+	}
+
+	cache.value = name.trim();
+	return cache.value;
+}
+
+/** Container hosting the WordPress webserver for tests (port = wpTestsPort). */
+function findTestsContainer() {
+	return findContainer( 'tests-wordpress', { value: cachedWpContainer } );
+}
+
+/** Container with wp-cli installed (read/write WP state from the shell). */
+function findCliContainer() {
+	if ( cachedCliContainer ) {
+		return cachedCliContainer;
+	}
+	cachedCliContainer = findContainer( 'tests-cli', {
+		get value() {
+			return cachedCliContainer;
+		},
+		set value( v ) {
+			cachedCliContainer = v;
+		},
+	} );
+	return cachedCliContainer;
+}
+
+/**
+ * Run an arbitrary PHP snippet inside the tests-cli container via `wp eval`.
+ * Provides a JSON payload on stdin and returns stdout. Use this for surgical
+ * state mutations (form/feed meta) that are awkward through the admin UI.
+ *
+ * @param {object} payload
+ * @param {string} php - The PHP body. `$data` is the decoded payload.
+ * @returns {string} stdout
+ */
+function wpEval( payload, php ) {
+	const { execFileSync } = require( 'child_process' );
+	const container = findCliContainer();
+	const wrapped = `$data = json_decode( file_get_contents( 'php://stdin' ), true );\n${ php }`;
+
+	return execFileSync(
+		'docker',
+		[
+			'exec',
+			'-i',
+			container,
+			'wp',
+			'--allow-root',
+			'eval',
+			wrapped,
+		],
+		{
+			input: JSON.stringify( payload ),
+			encoding: 'utf8',
+		}
+	);
+}
+
+/**
+ * Add a notification to a form via REST. Uses the e2e-fixtures REST namespace
+ * for consistency with form/entry seeding, but the actual notification
+ * mutation is done via GFAPI through a small in-line PHP exec call.
+ *
+ * @param {number} formId
+ * @param {object} notification - { name, to, subject, message, gravityexport_attachment, gravityexport_attachment_type }
+ * @returns {Promise<string>} The created notification id.
+ */
+async function addNotification( formId, notification ) {
+	const out = wpEval(
+		{
+			formId,
+			notification: {
+				id: notification.id || `e2e_${ Date.now() }`,
+				name: notification.name || 'E2E Notification',
+				isActive: true,
+				to: notification.to || 'admin@example.test',
+				toType: 'email',
+				subject: notification.subject || 'E2E Test Notification',
+				message: notification.message || 'Body',
+				from: '{admin_email}',
+				event: 'form_submission',
+				gravityexport_attachment: notification.gravityexport_attachment ? '1' : '0',
+				gravityexport_attachment_type: notification.gravityexport_attachment_type || 'xlsx',
+			},
+		},
+		`
+		$form = GFAPI::get_form( (int) $data['formId'] );
+		if ( ! $form ) { fwrite( STDERR, 'no form' ); exit( 1 ); }
+		$notifications = isset( $form['notifications'] ) && is_array( $form['notifications'] ) ? $form['notifications'] : [];
+		$n = $data['notification'];
+		$notifications[ $n['id'] ] = $n;
+		$form['notifications'] = $notifications;
+		$res = GFAPI::update_form( $form );
+		if ( is_wp_error( $res ) ) { fwrite( STDERR, $res->get_error_message() ); exit( 1 ); }
+		echo $n['id'];
+		`
+	);
+
+	return out.trim();
+}
+
+/**
+ * Submit an entry to a form via fixtures REST (the simplest reliable trigger
+ * for `form_submission` notifications without driving the public frontend).
+ *
+ * @param {number} formId
+ * @param {object} values - { fieldId: value }
+ * @returns {Promise<number>} entry id
+ */
+async function submitEntryTriggeringNotifications( formId, values ) {
+	const out = wpEval(
+		{ formId, values },
+		`
+		$form = GFAPI::get_form( (int) $data['formId'] );
+		if ( ! $form ) { fwrite( STDERR, 'no form' ); exit( 1 ); }
+		$entry = $data['values'];
+		$entry['form_id'] = $form['id'];
+		$entry_id = GFAPI::add_entry( $entry );
+		if ( is_wp_error( $entry_id ) ) { fwrite( STDERR, $entry_id->get_error_message() ); exit( 1 ); }
+		$entry = GFAPI::get_entry( $entry_id );
+		GFAPI::send_notifications( $form, $entry, 'form_submission' );
+		echo $entry_id;
+		`
+	);
+
+	return parseInt( out.trim(), 10 );
+}
+
+/**
+ * Mutate the GravityExport feed meta for a form. Used by tests that need
+ * deterministic configuration (disabled fields, custom order, notes flag,
+ * transpose, attached notification) without driving the sortable UI.
+ *
+ * @param {number} formId
+ * @param {object} patch - Keys to merge into the feed's `meta` JSON.
+ */
+function patchExportFeedMeta( formId, patch ) {
+	wpEval(
+		{ formId, patch },
+		`
+		$addon = \\GFExcel\\Addon\\GravityExportAddon::get_instance();
+		$feed  = $addon->get_feed_by_form_id( (int) $data['formId'] );
+		if ( ! $feed ) { fwrite( STDERR, 'no feed' ); exit( 1 ); }
+		$settings = isset( $feed['meta'] ) && is_array( $feed['meta'] ) ? $feed['meta'] : [];
+		foreach ( $data['patch'] as $key => $value ) {
+			$settings[ $key ] = $value;
+		}
+		$addon->save_feed_settings( (int) $feed['id'], (int) $feed['form_id'], $settings );
+		echo 'ok';
+		`
+	);
+}
+
+module.exports = {
+	...base,
+	expect,
+	goToFormSettings,
+	enableDownloadUrl,
+	readDownloadUrl,
+	saveSettings,
+	submitSettingsForm,
+	fetchDownload,
+	parseCsv,
+	getCapturedEmails,
+	clearCapturedEmails,
+	readAttachmentBytes,
+	addNotification,
+	submitEntryTriggeringNotifications,
+	patchExportFeedMeta,
+	wpEval,
+	FORM_SETTINGS_PATH,
+	NOTIFICATIONS_LIST_PATH,
+	NEW_NOTIFICATION_PATH,
+};

--- a/tests/E2E/helpers/test-helpers.js
+++ b/tests/E2E/helpers/test-helpers.js
@@ -199,21 +199,87 @@ function parseCsv( body ) {
 	return rows.filter( ( r ) => r.some( ( c ) => c.length > 0 ) );
 }
 
+const MAIL_URL = () => `${ testsBaseURL }/wp-json/gk-e2e/v1/mail`;
+const MAIL_HEADERS = { 'X-E2E-TEST-TOKEN': 'gravitykit-e2e-test' };
+
+/**
+ * Whether an error from `fetch` looks like a transient connection-level
+ * failure that's worth retrying.
+ *
+ * Apache in the wp-env container has a 5s KeepAlive timeout. Long-running
+ * suites reuse connections from a previous test's request, and the server
+ * may have already closed the socket — surfacing as ECONNRESET / EPIPE /
+ * "socket hang up". A single retry on a fresh socket reliably succeeds.
+ *
+ * @param {Error} err
+ * @returns {boolean}
+ */
+function isTransientNetworkError( err ) {
+	if ( ! err ) {
+		return false;
+	}
+	const msg = String( err.message || err );
+	const code = err.code || err.cause?.code || '';
+	return (
+		/socket hang up/i.test( msg ) ||
+		/ECONNRESET/.test( msg ) ||
+		/ECONNREFUSED/.test( msg ) ||
+		/EPIPE/.test( msg ) ||
+		/fetch failed/i.test( msg ) ||
+		code === 'ECONNRESET' ||
+		code === 'EPIPE' ||
+		code === 'UND_ERR_SOCKET'
+	);
+}
+
+/**
+ * fetch() wrapper that retries on transient connection-level failures.
+ *
+ * We use Node's global fetch rather than the Playwright APIRequestContext
+ * for the mail endpoints because:
+ *  1) The APIRequestContext aggressively reuses HTTP connections, and
+ *     Apache's keep-alive idle timeout (5s) causes "socket hang up" when
+ *     the next test reuses a stale connection.
+ *  2) The mail endpoint doesn't need browser cookies — auth is the
+ *     X-E2E-TEST-TOKEN header.
+ *
+ * @param {string} url
+ * @param {object} options
+ * @returns {Promise<Response>}
+ */
+async function fetchWithRetry( url, options = {}, { tries = 4, baseDelayMs = 100 } = {} ) {
+	let lastError;
+	for ( let attempt = 0; attempt < tries; attempt++ ) {
+		try {
+			return await fetch( url, options );
+		} catch ( err ) {
+			lastError = err;
+			if ( ! isTransientNetworkError( err ) ) {
+				throw err;
+			}
+			// Exponential backoff: 100 → 200 → 400 → 800 ms.
+			await new Promise( ( r ) =>
+				setTimeout( r, baseDelayMs * 2 ** attempt )
+			);
+		}
+	}
+	throw lastError;
+}
+
 /**
  * Fetch captured emails from the mail-capture mu-plugin.
  *
- * @param {import('@playwright/test').APIRequestContext} request
+ * `request` is accepted for backwards compatibility but ignored — the
+ * implementation uses Node fetch with retries (see fetchWithRetry).
+ *
  * @returns {Promise<Array>}
  */
-async function getCapturedEmails( request ) {
-	const url = `${ testsBaseURL }/wp-json/gk-e2e/v1/mail`;
-	const response = await request.get( url, {
-		headers: { 'X-E2E-TEST-TOKEN': 'gravitykit-e2e-test' },
-	} );
+async function getCapturedEmails() {
+	const response = await fetchWithRetry( MAIL_URL(), { headers: MAIL_HEADERS } );
 
-	if ( ! response.ok() ) {
+	if ( ! response.ok ) {
 		throw new Error(
-			`Mail capture GET failed: ${ response.status() } ${ response.statusText() }`
+			`Mail capture GET failed: ${ response.status } ${ response.statusText }`
 		);
 	}
 
@@ -222,20 +288,52 @@ async function getCapturedEmails( request ) {
 }
 
 /**
- * Clear all captured emails. Call in beforeEach to avoid cross-test bleed.
+ * Poll the mail-capture endpoint until a message matching the predicate
+ * appears, or the timeout expires. The mu-plugin writes the JSON record
+ * synchronously inside `pre_wp_mail`, so as soon as the wp-cli call that
+ * triggered the notification returns, the message is on disk — but we
+ * still poll defensively because PHP opcache + bind-mounts have produced
+ * sub-second race windows.
  *
- * @param {import('@playwright/test').APIRequestContext} request
+ * @param {(message: object) => boolean} predicate
+ * @param {object} [opts]
+ * @param {number} [opts.timeoutMs=10000]
+ * @param {number} [opts.intervalMs=100]
+ * @returns {Promise<object>} The matched message.
  */
-async function clearCapturedEmails( request ) {
-	const url = `${ testsBaseURL }/wp-json/gk-e2e/v1/mail`;
-	const response = await request.delete( url, {
-		headers: { 'X-E2E-TEST-TOKEN': 'gravitykit-e2e-test' },
+async function waitForCapturedEmail( predicate, opts = {} ) {
+	const { timeoutMs = 10000, intervalMs = 100 } = opts;
+	const deadline = Date.now() + timeoutMs;
+	let lastSeenSubjects = [];
+
+	while ( Date.now() < deadline ) {
+		const messages = await getCapturedEmails();
+		lastSeenSubjects = messages.map( ( m ) => m.subject );
+		const hit = messages.find( predicate );
+		if ( hit ) {
+			return hit;
+		}
+		await new Promise( ( r ) => setTimeout( r, intervalMs ) );
+	}
+
+	throw new Error(
+		`waitForCapturedEmail: no message matched predicate within ${ timeoutMs }ms.\n` +
+			`Last seen subjects: ${ JSON.stringify( lastSeenSubjects ) }`
+	);
+}
+
+/**
+ * Clear all captured emails. Call in beforeEach to avoid cross-test bleed.
+ * Accepts `request` for backwards compatibility but ignores it.
+ */
+async function clearCapturedEmails() {
+	const response = await fetchWithRetry( MAIL_URL(), {
+		method: 'DELETE',
+		headers: MAIL_HEADERS,
 	} );
 
-	if ( ! response.ok() ) {
-		throw new Error(
-			`Mail capture DELETE failed: ${ response.status() }`
-		);
+	if ( ! response.ok ) {
+		throw new Error( `Mail capture DELETE failed: ${ response.status }` );
 	}
 }
 
@@ -455,6 +553,7 @@ module.exports = {
 	fetchDownload,
 	parseCsv,
 	getCapturedEmails,
+	waitForCapturedEmail,
 	clearCapturedEmails,
 	readAttachmentBytes,
 	addNotification,

--- a/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
+++ b/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
@@ -144,6 +144,13 @@ add_action(
 						@unlink( $file );
 					}
 
+					// Also wipe stored attachment copies — otherwise the
+					// uploads dir grows unbounded across long-running suites.
+					$attachments = glob( $dir . 'attachments/*' ) ?: [];
+					foreach ( $attachments as $attachment ) {
+						@unlink( $attachment );
+					}
+
 					return new WP_REST_Response( [ 'cleared' => count( $files ) ], 200 );
 				},
 			]

--- a/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
+++ b/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Plugin Name: E2E Mail Capture
+ * Description: Short-circuits wp_mail and exposes captured messages via REST. Used only by Playwright tests.
+ *
+ * Auth: same X-E2E-TEST-TOKEN header as @gravitykit/e2e-fixtures (constant 'gravitykit-e2e-test').
+ *
+ * @package GravityExport_Lite_E2E
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'GK_E2E_MAIL_TOKEN' ) ) {
+	define( 'GK_E2E_MAIL_TOKEN', 'gravitykit-e2e-test' );
+}
+
+if ( ! function_exists( 'gk_e2e_mail_dir' ) ) {
+	/**
+	 * Resolve the capture directory inside uploads.
+	 *
+	 * @return string Absolute path with trailing slash.
+	 */
+	function gk_e2e_mail_dir() {
+		$uploads = wp_upload_dir( null, false );
+		$dir     = trailingslashit( $uploads['basedir'] ) . 'e2e-mail-capture/';
+
+		if ( ! is_dir( $dir ) ) {
+			wp_mkdir_p( $dir );
+		}
+
+		return $dir;
+	}
+}
+
+// Short-circuit wp_mail: write payload + attachments to disk, return true.
+add_filter(
+	'pre_wp_mail',
+	static function ( $null, $atts ) {
+		$dir = gk_e2e_mail_dir();
+
+		$to          = (array) ( $atts['to'] ?? [] );
+		$subject     = (string) ( $atts['subject'] ?? '' );
+		$message     = (string) ( $atts['message'] ?? '' );
+		$headers     = (array) ( $atts['headers'] ?? [] );
+		$attachments = (array) ( $atts['attachments'] ?? [] );
+
+		$attachment_records = [];
+
+		$copy_dir = $dir . 'attachments/';
+		if ( ! is_dir( $copy_dir ) ) {
+			wp_mkdir_p( $copy_dir );
+		}
+
+		foreach ( $attachments as $path ) {
+			if ( ! is_string( $path ) || ! is_readable( $path ) ) {
+				continue;
+			}
+
+			$size  = filesize( $path );
+			$mime  = function_exists( 'mime_content_type' ) ? mime_content_type( $path ) : null;
+			$sha1  = sha1_file( $path );
+			$base  = basename( $path );
+			// Copy the attachment to a stable location: notification senders
+			// often delete the source file after wp_mail returns
+			// (e.g. GravityExport's gform_after_email cleanup), so tests
+			// need an independent copy to read full bytes from.
+			$copy  = $copy_dir . $sha1 . '-' . $base;
+			if ( ! file_exists( $copy ) ) {
+				@copy( $path, $copy );
+			}
+
+			$attachment_records[] = [
+				'filename' => $base,
+				'size'     => $size === false ? 0 : (int) $size,
+				'mime'     => $mime ?: '',
+				'sha1'     => $sha1,
+				'path'     => $copy,
+			];
+		}
+
+		$record = [
+			'id'          => uniqid( 'mail_', true ),
+			'timestamp'   => microtime( true ),
+			'to'          => $to,
+			'subject'     => $subject,
+			'message'     => $message,
+			'headers'     => $headers,
+			'attachments' => $attachment_records,
+		];
+
+		$filename = $dir . sprintf( '%010d-%s.json', floor( $record['timestamp'] ), $record['id'] );
+		file_put_contents( $filename, wp_json_encode( $record, JSON_UNESCAPED_SLASHES ) );
+
+		// Return non-null to short-circuit the real wp_mail.
+		return true;
+	},
+	10,
+	2
+);
+
+// REST endpoints — list and clear captured emails.
+add_action(
+	'rest_api_init',
+	static function () {
+		register_rest_route(
+			'gk-e2e/v1',
+			'/mail',
+			[
+				'methods'             => 'GET',
+				'permission_callback' => 'gk_e2e_mail_check_permission',
+				'callback'            => static function () {
+					$dir   = gk_e2e_mail_dir();
+					$files = glob( $dir . '*.json' ) ?: [];
+					sort( $files );
+
+					$messages = [];
+
+					foreach ( $files as $file ) {
+						$decoded = json_decode( (string) file_get_contents( $file ), true );
+
+						if ( is_array( $decoded ) ) {
+							$messages[] = $decoded;
+						}
+					}
+
+					return new WP_REST_Response( [ 'messages' => $messages ], 200 );
+				},
+			]
+		);
+
+		register_rest_route(
+			'gk-e2e/v1',
+			'/mail',
+			[
+				'methods'             => 'DELETE',
+				'permission_callback' => 'gk_e2e_mail_check_permission',
+				'callback'            => static function () {
+					$dir   = gk_e2e_mail_dir();
+					$files = glob( $dir . '*.json' ) ?: [];
+
+					foreach ( $files as $file ) {
+						@unlink( $file );
+					}
+
+					return new WP_REST_Response( [ 'cleared' => count( $files ) ], 200 );
+				},
+			]
+		);
+	}
+);
+
+if ( ! function_exists( 'gk_e2e_mail_check_permission' ) ) {
+	function gk_e2e_mail_check_permission( WP_REST_Request $request ) {
+		return GK_E2E_MAIL_TOKEN === $request->get_header( 'X-E2E-TEST-TOKEN' );
+	}
+}

--- a/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
+++ b/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
@@ -18,16 +18,30 @@ if ( ! defined( 'GK_E2E_MAIL_TOKEN' ) ) {
 
 if ( ! function_exists( 'gk_e2e_mail_dir' ) ) {
 	/**
-	 * Resolve the capture directory inside uploads.
+	 * Resolve the capture directory.
+	 *
+	 * The previous home, `wp-content/uploads`, is created by Apache
+	 * (www-data, UID 33) inside the tests-wordpress container. wp-env's
+	 * tests-cli container runs as the host user (UID 501 locally, but
+	 * UID 3434 on CircleCI), and that user cannot write into a
+	 * www-data-owned uploads dir — so the JSON capture never lands and
+	 * waitForCapturedEmail times out with an empty inbox.
+	 *
+	 * We instead write to `wp-content/e2e-mail-capture/`, which is a
+	 * dedicated host directory bind-mounted via wp-env.config.js's
+	 * additionalMappings. The host directory is owned by the host user,
+	 * mode 0777, so the cli container can always write to it. Apache
+	 * (www-data) only needs to READ for the REST endpoint, which works
+	 * via the world-readable mode bits.
 	 *
 	 * @return string Absolute path with trailing slash.
 	 */
 	function gk_e2e_mail_dir() {
-		$uploads = wp_upload_dir( null, false );
-		$dir     = trailingslashit( $uploads['basedir'] ) . 'e2e-mail-capture/';
+		$dir = ( defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR : ABSPATH . 'wp-content' )
+			. '/e2e-mail-capture/';
 
 		if ( ! is_dir( $dir ) ) {
-			wp_mkdir_p( $dir );
+			@mkdir( $dir, 0777, true );
 		}
 
 		return $dir;

--- a/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
+++ b/tests/E2E/setup/mu-plugins/e2e-mail-capture.php
@@ -80,9 +80,11 @@ add_filter(
 			// often delete the source file after wp_mail returns
 			// (e.g. GravityExport's gform_after_email cleanup), so tests
 			// need an independent copy to read full bytes from.
-			$copy  = $copy_dir . $sha1 . '-' . $base;
-			if ( ! file_exists( $copy ) ) {
-				@copy( $path, $copy );
+			$copy = $copy_dir . $sha1 . '-' . $base;
+			if ( ! file_exists( $copy ) && ! @copy( $path, $copy ) ) {
+				// Source went away before we could grab it; skip rather than
+				// record a path tests would fail to read.
+				continue;
 			}
 
 			$attachment_records[] = [
@@ -104,8 +106,14 @@ add_filter(
 			'attachments' => $attachment_records,
 		];
 
+		// Atomic write: a parallel worker hitting GET /mail mid-write would
+		// otherwise see a half-flushed JSON file. Write to a temp file, then
+		// rename — POSIX rename is atomic within the same filesystem.
 		$filename = $dir . sprintf( '%010d-%s.json', floor( $record['timestamp'] ), $record['id'] );
-		file_put_contents( $filename, wp_json_encode( $record, JSON_UNESCAPED_SLASHES ) );
+		$tmp      = $filename . '.tmp';
+		if ( false !== file_put_contents( $tmp, wp_json_encode( $record, JSON_UNESCAPED_SLASHES ) ) ) {
+			@rename( $tmp, $filename );
+		}
 
 		// Return non-null to short-circuit the real wp_mail.
 		return true;

--- a/tests/E2E/setup/playwright.config.js
+++ b/tests/E2E/setup/playwright.config.js
@@ -13,12 +13,4 @@ module.exports = createPlaywrightConfig( {
 	testDir: '../tests',
 	use: { baseURL: testsBaseURL },
 	webServer: { url: testsBaseURL },
-	// The bootstrap default is `workers: '50%'`. The GravityExport suite
-	// shares a single wp-env WordPress instance, and several specs mutate
-	// global state (rewrite rules on feed-enable, the gf_addon_feed table,
-	// the captured-mail inbox). With multiple workers we see intermittent
-	// contention on those globals. Run serially — the suite is fast
-	// enough (≈40s end-to-end) that the simplicity is worth more than the
-	// parallel speedup.
-	workers: 1,
 } );

--- a/tests/E2E/setup/playwright.config.js
+++ b/tests/E2E/setup/playwright.config.js
@@ -6,7 +6,24 @@ const { createPlaywrightConfig, readPorts } = require( '@gravitykit/e2e-bootstra
 // login, and tests hit the empty dev instance and REST returns the login page
 // instead of JSON (see @debugging/14).
 const ports = readPorts( __dirname );
-const testsBaseURL = `${ process.env.WP_ENV_URL || 'http://localhost' }:${ ports.wpTestsPort }`;
+
+// Build the tests base URL. If WP_ENV_URL already includes a port we honor it
+// as-is; otherwise we append the resolved wpTestsPort. Naïvely concatenating
+// `:${ports.wpTestsPort}` would produce invalid URLs like
+// `http://localhost:8888:8801` when someone exports a fully-specified URL.
+const testsBaseURL = ( () => {
+	const raw = process.env.WP_ENV_URL || 'http://localhost';
+	try {
+		const u = new URL( raw );
+		if ( u.port ) {
+			return u.toString().replace( /\/$/, '' );
+		}
+		u.port = String( ports.wpTestsPort );
+		return u.toString().replace( /\/$/, '' );
+	} catch {
+		return `${ raw }:${ ports.wpTestsPort }`;
+	}
+} )();
 
 module.exports = createPlaywrightConfig( {
 	setupDir: __dirname,

--- a/tests/E2E/setup/playwright.config.js
+++ b/tests/E2E/setup/playwright.config.js
@@ -1,6 +1,16 @@
-const { createPlaywrightConfig } = require( '@gravitykit/e2e-bootstrap' );
+const { createPlaywrightConfig, readPorts } = require( '@gravitykit/e2e-bootstrap' );
+
+// wp-env:cli targets the `tests-cli` container (wpTestsPort, 8801), so plugins,
+// licenses, and REST routes are only present on the tests instance. Point
+// Playwright and the fixtures API at the same port; otherwise global setup,
+// login, and tests hit the empty dev instance and REST returns the login page
+// instead of JSON (see @debugging/14).
+const ports = readPorts( __dirname );
+const testsBaseURL = `${ process.env.WP_ENV_URL || 'http://localhost' }:${ ports.wpTestsPort }`;
 
 module.exports = createPlaywrightConfig( {
 	setupDir: __dirname,
 	testDir: '../tests',
+	use: { baseURL: testsBaseURL },
+	webServer: { url: testsBaseURL },
 } );

--- a/tests/E2E/setup/playwright.config.js
+++ b/tests/E2E/setup/playwright.config.js
@@ -13,4 +13,12 @@ module.exports = createPlaywrightConfig( {
 	testDir: '../tests',
 	use: { baseURL: testsBaseURL },
 	webServer: { url: testsBaseURL },
+	// The bootstrap default is `workers: '50%'`. The GravityExport suite
+	// shares a single wp-env WordPress instance, and several specs mutate
+	// global state (rewrite rules on feed-enable, the gf_addon_feed table,
+	// the captured-mail inbox). With multiple workers we see intermittent
+	// contention on those globals. Run serially — the suite is fast
+	// enough (≈40s end-to-end) that the simplicity is worth more than the
+	// parallel speedup.
+	workers: 1,
 } );

--- a/tests/E2E/setup/wp-env.config.js
+++ b/tests/E2E/setup/wp-env.config.js
@@ -1,7 +1,18 @@
 const path = require( 'path' );
+const fs = require( 'fs' );
 const { generateWpEnvConfig, loadEnv } = require( '@gravitykit/e2e-bootstrap' );
 
 loadEnv( path.resolve( __dirname, '../../../.env' ) );
+
+// Ensure the host-side capture directory exists before wp-env starts so the
+// bind-mount resolves cleanly. Mode 0777 because both the host user (cli
+// writes) and Apache's www-data (REST reads) need access, and the simplest
+// way to guarantee that across container UIDs is fully permissive bits.
+const mailCaptureHostDir = path.resolve( __dirname, 'mail-capture' );
+if ( ! fs.existsSync( mailCaptureHostDir ) ) {
+	fs.mkdirSync( mailCaptureHostDir, { recursive: true, mode: 0o777 } );
+}
+fs.chmodSync( mailCaptureHostDir, 0o777 );
 
 generateWpEnvConfig( {
 	outputDir: __dirname,
@@ -10,6 +21,10 @@ generateWpEnvConfig( {
 	additionalMappings: {
 		// wp_mail short-circuit + REST inspection endpoint used by notification specs.
 		'wp-content/mu-plugins/e2e-mail-capture.php': './mu-plugins/e2e-mail-capture.php',
+		// Bind-mounted capture directory shared between tests-wordpress and
+		// tests-cli. Avoids the cross-container UID mismatch that prevented
+		// the cli (host UID) from writing into a www-data-owned uploads dir.
+		'wp-content/e2e-mail-capture': './mail-capture',
 	},
 } ).catch( ( err ) => {
 	console.error( err );

--- a/tests/E2E/setup/wp-env.config.js
+++ b/tests/E2E/setup/wp-env.config.js
@@ -7,6 +7,10 @@ generateWpEnvConfig( {
 	outputDir: __dirname,
 	pluginPath: '../../..',
 	additionalLifecycleCommands: [],
+	additionalMappings: {
+		// wp_mail short-circuit + REST inspection endpoint used by notification specs.
+		'wp-content/mu-plugins/e2e-mail-capture.php': './mu-plugins/e2e-mail-capture.php',
+	},
 } ).catch( ( err ) => {
 	console.error( err );
 	process.exit( 1 );

--- a/tests/E2E/tests/data-shaping/entry-notes.spec.js
+++ b/tests/E2E/tests/data-shaping/entry-notes.spec.js
@@ -1,0 +1,84 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	parseCsv,
+	patchExportFeedMeta,
+	wpEval,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Entry notes column', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'enabling the Notes setting renders a notes column with the entry note text', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+
+		const noteText = 'E2E-NOTE-' + Date.now();
+
+		// Attach a note to entry #1 (the first seeded entry).
+		const firstEntryId = data.entries[ 0 ].id;
+		wpEval(
+			{ entryId: firstEntryId, note: noteText },
+			`
+			\\RGFormsModel::add_note(
+				(int) $data['entryId'],
+				1,
+				'admin',
+				$data['note']
+			);
+			echo 'ok';
+			`
+		);
+
+		// Baseline (notes flag off): the CSV header must NOT carry a Notes
+		// column. This catches accidental defaulting in the addon.
+		const baselineHeader = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		)[ 0 ];
+		expect(
+			baselineHeader,
+			'Notes column should be absent until the setting is enabled'
+		).not.toContain( 'Notes' );
+
+		patchExportFeedMeta( data.form_id, { enable_notes: '1' } );
+
+		const rows = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		);
+		const header = rows[ 0 ];
+		const notesIdx = header.indexOf( 'Notes' );
+
+		expect(
+			notesIdx,
+			'Notes column should appear once the setting is on'
+		).toBeGreaterThanOrEqual( 0 );
+
+		// One of the data rows now carries our note string.
+		const notesValues = rows.slice( 1 ).map( ( r ) => r[ notesIdx ] );
+		expect(
+			notesValues.some( ( v ) => v && v.includes( noteText ) ),
+			'At least one entry row should contain our seeded note text'
+		).toBe( true );
+	} );
+} );

--- a/tests/E2E/tests/data-shaping/transpose.spec.js
+++ b/tests/E2E/tests/data-shaping/transpose.spec.js
@@ -1,0 +1,69 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	parseCsv,
+	patchExportFeedMeta,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Transpose mode', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'enabling transpose makes fields the rows and entries the columns', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+
+		// Baseline: rows = header + entries.
+		const baselineRows = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		);
+		const baselineColumnCount = baselineRows[ 0 ].length;
+		const baselineRowCount = baselineRows.length;
+
+		patchExportFeedMeta( data.form_id, { is_transposed: '1' } );
+
+		const transposed = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		);
+
+		// After transposing: rows ↔ columns. The new row count equals
+		// the original column count, and the new column count equals
+		// the original row count.
+		expect(
+			transposed.length,
+			'Transposed row count should equal baseline column count'
+		).toBe( baselineColumnCount );
+		expect(
+			transposed[ 0 ].length,
+			'Transposed column count should equal baseline row count'
+		).toBe( baselineRowCount );
+
+		// Field labels now appear in the first column (one per row).
+		const firstColumn = transposed.map( ( r ) => r[ 0 ] );
+		expect(
+			firstColumn,
+			'First Name label appears as a row label in transpose mode'
+		).toContain( 'First Name' );
+		expect( firstColumn ).toContain( 'Email' );
+	} );
+} );

--- a/tests/E2E/tests/download-url/download-csv.spec.js
+++ b/tests/E2E/tests/download-url/download-csv.spec.js
@@ -1,0 +1,67 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	parseCsv,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Download via URL (CSV extension swap)', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'appending .csv to the download URL returns text/csv with the right rows', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+		const csvUrl = `${ url }.csv`;
+
+		const response = await fetchDownload( request, csvUrl );
+
+		expect( response.status ).toBe( 200 );
+		expect(
+			response.headers[ 'content-type' ],
+			'Content-Type should be CSV'
+		).toMatch( /text\/csv|application\/csv/i );
+		expect(
+			response.headers[ 'content-disposition' ],
+			'Filename should end in .csv'
+		).toMatch( /attachment;.*\.csv/i );
+
+		const rows = parseCsv( response.body );
+
+		// simple.json has 4 entries — 1 header + 4 data rows.
+		expect(
+			rows.length,
+			'Row count should be header + 4 entries'
+		).toBe( 5 );
+
+		const header = rows[ 0 ];
+		expect(
+			header,
+			'Header should include the form\'s two visible fields'
+		).toEqual( expect.arrayContaining( [ 'First Name', 'Email' ] ) );
+
+		// Spot-check a known entry value.
+		const firstNameCol = header.indexOf( 'First Name' );
+		const names = rows.slice( 1 ).map( ( r ) => r[ firstNameCol ] );
+		expect( names ).toEqual( expect.arrayContaining( [ 'Alice', 'Bob' ] ) );
+	} );
+} );

--- a/tests/E2E/tests/download-url/download-xlsx.spec.js
+++ b/tests/E2E/tests/download-url/download-xlsx.spec.js
@@ -1,0 +1,58 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Download via URL (XLSX default)', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'anonymous GET on the download URL returns a valid .xlsx attachment', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+
+		// Use a fresh request context so we are NOT carrying the admin cookies.
+		const response = await fetchDownload( request, url );
+
+		expect( response.status ).toBe( 200 );
+
+		expect(
+			response.headers[ 'content-type' ],
+			'Content-Type should be the Excel SpreadsheetML MIME'
+		).toMatch(
+			/application\/vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet/i
+		);
+
+		expect(
+			response.headers[ 'content-disposition' ],
+			'Should be an attachment with a .xlsx filename'
+		).toMatch( /attachment;.*\.xlsx/i );
+
+		// XLSX files are ZIP containers — the magic bytes are "PK\x03\x04".
+		expect(
+			response.body.length,
+			'Body should be a non-trivial binary'
+		).toBeGreaterThan( 512 );
+		expect( response.body.slice( 0, 2 ).toString( 'binary' ) ).toBe( 'PK' );
+	} );
+} );

--- a/tests/E2E/tests/download-url/enable-download-url.spec.js
+++ b/tests/E2E/tests/download-url/enable-download-url.spec.js
@@ -1,0 +1,63 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	goToFormSettings,
+	enableDownloadUrl,
+	readDownloadUrl,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Enable Download URL', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'enabling the download URL renders a copyable URL that persists across reloads', async ( {
+		page,
+	} ) => {
+		await goToFormSettings( page, data.form_id );
+
+		// Pristine state: only the activation button is present.
+		const activate = page.locator(
+			'button[name="gform-settings-save"][value="download_url_enable"]'
+		);
+		await expect( activate ).toBeVisible();
+		await expect(
+			page.locator( 'input[name="_gform_setting_hash"]' )
+		).toHaveCount( 0 );
+
+		await enableDownloadUrl( page, data.form_id );
+
+		const url = await readDownloadUrl( page );
+
+		expect(
+			url,
+			'URL should be on the gravityexport-lite endpoint with a hex hash suffix'
+		).toMatch( /\/gravityexport-lite\/[a-f0-9]+$/ );
+
+		// Regenerate, Disable, Copy controls are visible once enabled.
+		await expect( page.locator( '#download-url-reset' ) ).toBeVisible();
+		await expect( page.locator( '#download-url-disable' ) ).toBeVisible();
+		await expect(
+			page.locator( 'button.copy-attachment-url' )
+		).toBeVisible();
+
+		// Reload — URL must survive.
+		await page.reload();
+		await expect(
+			page.locator( 'input[name="_gform_setting_hash"]' )
+		).toHaveValue( url );
+	} );
+} );

--- a/tests/E2E/tests/download-url/regenerate-disable.spec.js
+++ b/tests/E2E/tests/download-url/regenerate-disable.spec.js
@@ -1,0 +1,88 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	submitSettingsForm,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Regenerate and Disable Download URL', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'regenerating swaps the hash and kills the previous URL; disabling removes access entirely', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const originalUrl = await readDownloadUrl( page );
+
+		// Confirm the original URL works first so we have a clean baseline.
+		const initialResponse = await fetchDownload( request, originalUrl );
+		expect( initialResponse.status, 'baseline URL should be live' ).toBe( 200 );
+
+		// Regenerate.
+		await submitSettingsForm( page, '#download-url-reset' );
+		await expect(
+			page.locator( 'input[name="_gform_setting_hash"]' )
+		).not.toHaveValue( originalUrl );
+
+		const newUrl = await readDownloadUrl( page );
+		expect(
+			newUrl,
+			'Regenerate must produce a different URL'
+		).not.toBe( originalUrl );
+		expect( newUrl ).toMatch( /\/gravityexport-lite\/[a-f0-9]+$/ );
+
+		// Old URL must be dead.
+		const oldResponse = await fetchDownload( request, originalUrl );
+		expect(
+			oldResponse.status,
+			'After regenerate the previous URL must not return a file'
+		).not.toBe( 200 );
+
+		// New URL still works.
+		const liveResponse = await fetchDownload( request, newUrl );
+		expect( liveResponse.status, 'New URL serves the export' ).toBe( 200 );
+
+		// Disable.
+		await submitSettingsForm( page, '#download-url-disable' );
+		await expect(
+			page.locator(
+				'button[name="gform-settings-save"][value="download_url_enable"]'
+			)
+		).toBeVisible();
+
+		// Activation button is back; URL input is gone.
+		await expect(
+			page.locator(
+				'button[name="gform-settings-save"][value="download_url_enable"]'
+			)
+		).toBeVisible();
+		await expect(
+			page.locator( 'input[name="_gform_setting_hash"]' )
+		).toHaveCount( 0 );
+
+		// And the URL is no longer fulfillable.
+		const disabledResponse = await fetchDownload( request, newUrl );
+		expect(
+			disabledResponse.status,
+			'Disabled URL must not serve the file'
+		).not.toBe( 200 );
+	} );
+} );

--- a/tests/E2E/tests/download-url/regenerate-disable.spec.js
+++ b/tests/E2E/tests/download-url/regenerate-disable.spec.js
@@ -60,15 +60,8 @@ test.describe( 'GravityExport Lite — Regenerate and Disable Download URL', () 
 		const liveResponse = await fetchDownload( request, newUrl );
 		expect( liveResponse.status, 'New URL serves the export' ).toBe( 200 );
 
-		// Disable.
+		// Disable. Activation button is back; URL input is gone.
 		await submitSettingsForm( page, '#download-url-disable' );
-		await expect(
-			page.locator(
-				'button[name="gform-settings-save"][value="download_url_enable"]'
-			)
-		).toBeVisible();
-
-		// Activation button is back; URL input is gone.
 		await expect(
 			page.locator(
 				'button[name="gform-settings-save"][value="download_url_enable"]'

--- a/tests/E2E/tests/fields/disable-field.spec.js
+++ b/tests/E2E/tests/fields/disable-field.spec.js
@@ -1,0 +1,71 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	parseCsv,
+	patchExportFeedMeta,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Disabled fields are excluded from the export', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'disabling the Email field removes its column from the CSV download', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+
+		// Baseline: Email column is present.
+		const baseline = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		);
+		expect(
+			baseline[ 0 ],
+			'Baseline header should include Email'
+		).toContain( 'Email' );
+		const baselineRowCount = baseline.length;
+
+		// Disable field id=2 (Email) via the persisted feed meta. The
+		// addon reads from `meta/export-fields/disabled` as a CSV string
+		// (see FieldsRepository::getDisabledFields). Writing it directly
+		// is what the sortable UI would do, minus the JS resync timing.
+		patchExportFeedMeta( data.form_id, {
+			'export-fields': { disabled: '2', enabled: '' },
+		} );
+
+		const rows = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		);
+
+		expect(
+			rows[ 0 ],
+			'Disabled Email field must not appear in the header'
+		).not.toContain( 'Email' );
+		expect(
+			rows[ 0 ],
+			'Other fields are still present'
+		).toContain( 'First Name' );
+		expect(
+			rows.length,
+			'Row count is unchanged — only column is removed'
+		).toBe( baselineRowCount );
+	} );
+} );

--- a/tests/E2E/tests/fields/sort-order.spec.js
+++ b/tests/E2E/tests/fields/sort-order.spec.js
@@ -1,0 +1,62 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	parseCsv,
+	patchExportFeedMeta,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Field sort order drives column order', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'putting Email ahead of First Name swaps their column positions', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+
+		// Baseline: First Name precedes Email.
+		const baseline = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		)[ 0 ];
+		expect( baseline.indexOf( 'First Name' ) ).toBeLessThan(
+			baseline.indexOf( 'Email' )
+		);
+
+		// Promote Email (field id 2) ahead of First Name (id 1) by writing
+		// the ordered enabled list (CSV) into the feed meta. The plugin
+		// renders columns in this order.
+		patchExportFeedMeta( data.form_id, {
+			'export-fields': { enabled: '2,1', disabled: '' },
+		} );
+
+		const header = parseCsv(
+			( await fetchDownload( request, `${ url }.csv` ) ).body
+		)[ 0 ];
+
+		expect( header ).toContain( 'Email' );
+		expect( header ).toContain( 'First Name' );
+		expect(
+			header.indexOf( 'Email' ),
+			'Email must precede First Name after the reorder'
+		).toBeLessThan( header.indexOf( 'First Name' ) );
+	} );
+} );

--- a/tests/E2E/tests/notifications/attach-csv.spec.js
+++ b/tests/E2E/tests/notifications/attach-csv.spec.js
@@ -1,0 +1,90 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	patchExportFeedMeta,
+	addNotification,
+	submitEntryTriggeringNotifications,
+	getCapturedEmails,
+	readAttachmentBytes,
+	parseCsv,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Attach single-entry export to a notification (CSV)', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'a new entry triggers the configured notification with a CSV attachment of just that entry', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+
+		// Subject is unique per spec/run so we can pick our own message out
+		// of the shared mail-capture inbox without racing parallel workers.
+		const subject = `E2E CSV ${ data.test_id }`;
+
+		const notificationId = await addNotification( data.form_id, {
+			name: 'E2E CSV Attachment',
+			to: 'csv-target@example.test',
+			subject,
+		} );
+
+		// Point the addon at this notification and request CSV format.
+		patchExportFeedMeta( data.form_id, {
+			attachment_notification: notificationId,
+			file_extension: 'csv',
+		} );
+
+		const entryId = await submitEntryTriggeringNotifications( data.form_id, {
+			'1': 'Spec',
+			'2': 'spec@gravitykit.test',
+		} );
+		expect( entryId ).toBeGreaterThan( 0 );
+
+		const allMessages = await getCapturedEmails( request );
+		const messages = allMessages.filter( ( m ) => m.subject === subject );
+		expect(
+			messages,
+			'Exactly one notification with our spec-scoped subject should have been sent'
+		).toHaveLength( 1 );
+
+		const message = messages[ 0 ];
+		expect( message.to ).toContain( 'csv-target@example.test' );
+		expect(
+			message.attachments,
+			'Notification carries exactly one attachment'
+		).toHaveLength( 1 );
+
+		const attachment = message.attachments[ 0 ];
+		expect( attachment.filename ).toMatch( /\.csv$/i );
+		expect( attachment.size ).toBeGreaterThan( 0 );
+
+		const bytes = readAttachmentBytes( attachment );
+		const rows = parseCsv( bytes );
+
+		// Header + 1 row for the just-submitted entry only.
+		expect(
+			rows.length,
+			'CSV must contain exactly the one entry that triggered the notification (header + 1 row)'
+		).toBe( 2 );
+
+		const header = rows[ 0 ];
+		const firstNameIdx = header.indexOf( 'First Name' );
+		expect( rows[ 1 ][ firstNameIdx ] ).toBe( 'Spec' );
+	} );
+} );

--- a/tests/E2E/tests/notifications/attach-csv.spec.js
+++ b/tests/E2E/tests/notifications/attach-csv.spec.js
@@ -7,7 +7,7 @@ const {
 	patchExportFeedMeta,
 	addNotification,
 	submitEntryTriggeringNotifications,
-	getCapturedEmails,
+	waitForCapturedEmail,
 	readAttachmentBytes,
 	parseCsv,
 } = require( '../../helpers/test-helpers' );
@@ -30,7 +30,6 @@ test.describe( 'GravityExport Lite — Attach single-entry export to a notificat
 
 	test( 'a new entry triggers the configured notification with a CSV attachment of just that entry', async ( {
 		page,
-		request,
 	} ) => {
 		await enableDownloadUrl( page, data.form_id );
 
@@ -56,14 +55,13 @@ test.describe( 'GravityExport Lite — Attach single-entry export to a notificat
 		} );
 		expect( entryId ).toBeGreaterThan( 0 );
 
-		const allMessages = await getCapturedEmails( request );
-		const messages = allMessages.filter( ( m ) => m.subject === subject );
-		expect(
-			messages,
-			'Exactly one notification with our spec-scoped subject should have been sent'
-		).toHaveLength( 1 );
-
-		const message = messages[ 0 ];
+		// Wait for the notification — the mu-plugin writes the JSON record
+		// synchronously inside pre_wp_mail, but we poll defensively to
+		// absorb any sub-second race windows and transient connection
+		// drops from Apache's KeepAlive idle timeout.
+		const message = await waitForCapturedEmail(
+			( m ) => m.subject === subject
+		);
 		expect( message.to ).toContain( 'csv-target@example.test' );
 		expect(
 			message.attachments,

--- a/tests/E2E/tests/notifications/attach-xlsx.spec.js
+++ b/tests/E2E/tests/notifications/attach-xlsx.spec.js
@@ -1,0 +1,79 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	patchExportFeedMeta,
+	addNotification,
+	submitEntryTriggeringNotifications,
+	getCapturedEmails,
+	readAttachmentBytes,
+} = require( '../../helpers/test-helpers' );
+
+test.describe( 'GravityExport Lite — Attach single-entry export to a notification (XLSX)', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'a new entry triggers the configured notification with an XLSX attachment', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+
+		// Unique subject so we can pick our message out of the shared
+		// mail-capture inbox (parallel workers share the same uploads dir).
+		const subject = `E2E XLSX ${ data.test_id }`;
+
+		const notificationId = await addNotification( data.form_id, {
+			name: 'E2E XLSX Attachment',
+			to: 'xlsx-target@example.test',
+			subject,
+		} );
+
+		patchExportFeedMeta( data.form_id, {
+			attachment_notification: notificationId,
+			file_extension: 'xlsx',
+		} );
+
+		const entryId = await submitEntryTriggeringNotifications( data.form_id, {
+			'1': 'XlsxSpec',
+			'2': 'xlsx-spec@gravitykit.test',
+		} );
+		expect( entryId ).toBeGreaterThan( 0 );
+
+		const allMessages = await getCapturedEmails( request );
+		const messages = allMessages.filter( ( m ) => m.subject === subject );
+		expect(
+			messages,
+			'Exactly one notification with our spec-scoped subject'
+		).toHaveLength( 1 );
+
+		const message = messages[ 0 ];
+		expect( message.to ).toContain( 'xlsx-target@example.test' );
+		expect( message.attachments ).toHaveLength( 1 );
+
+		const attachment = message.attachments[ 0 ];
+		expect( attachment.filename ).toMatch( /\.xlsx$/i );
+		expect( attachment.size ).toBeGreaterThan( 512 );
+
+		const bytes = readAttachmentBytes( attachment );
+		// XLSX is a ZIP container — magic bytes are "PK".
+		expect(
+			bytes.slice( 0, 2 ).toString( 'binary' ),
+			'Attachment body should be a valid ZIP/XLSX container'
+		).toBe( 'PK' );
+	} );
+} );

--- a/tests/E2E/tests/notifications/attach-xlsx.spec.js
+++ b/tests/E2E/tests/notifications/attach-xlsx.spec.js
@@ -7,7 +7,7 @@ const {
 	patchExportFeedMeta,
 	addNotification,
 	submitEntryTriggeringNotifications,
-	getCapturedEmails,
+	waitForCapturedEmail,
 	readAttachmentBytes,
 } = require( '../../helpers/test-helpers' );
 
@@ -29,7 +29,6 @@ test.describe( 'GravityExport Lite — Attach single-entry export to a notificat
 
 	test( 'a new entry triggers the configured notification with an XLSX attachment', async ( {
 		page,
-		request,
 	} ) => {
 		await enableDownloadUrl( page, data.form_id );
 
@@ -54,14 +53,13 @@ test.describe( 'GravityExport Lite — Attach single-entry export to a notificat
 		} );
 		expect( entryId ).toBeGreaterThan( 0 );
 
-		const allMessages = await getCapturedEmails( request );
-		const messages = allMessages.filter( ( m ) => m.subject === subject );
-		expect(
-			messages,
-			'Exactly one notification with our spec-scoped subject'
-		).toHaveLength( 1 );
-
-		const message = messages[ 0 ];
+		// Poll the capture endpoint via Node fetch with retry — Playwright's
+		// APIRequestContext reuses keep-alive connections and Apache's idle
+		// timeout can drop them between specs (manifesting as "socket hang
+		// up").
+		const message = await waitForCapturedEmail(
+			( m ) => m.subject === subject
+		);
 		expect( message.to ).toContain( 'xlsx-target@example.test' );
 		expect( message.attachments ).toHaveLength( 1 );
 

--- a/tests/E2E/tests/permissions/logged-in-required.spec.js
+++ b/tests/E2E/tests/permissions/logged-in-required.spec.js
@@ -1,0 +1,71 @@
+const { test } = require( '@playwright/test' );
+const {
+	expect,
+	fixtures,
+	cleanup,
+	enableDownloadUrl,
+	readDownloadUrl,
+	fetchDownload,
+	patchExportFeedMeta,
+} = require( '../../helpers/test-helpers' );
+
+/**
+ * Plain unauthenticated GET via Node's global fetch. Playwright's
+ * APIRequestContext can carry browser cookies from the worker even when
+ * created via `request.newContext()` in some configurations, so we use the
+ * Node fetch primitive to guarantee an anonymous request.
+ */
+async function anonGet( url ) {
+	const response = await fetch( url, { redirect: 'manual' } );
+	return { status: response.status, body: Buffer.from( await response.arrayBuffer() ) };
+}
+
+test.describe( 'GravityExport Lite — Restrict download to logged-in users', () => {
+	let data;
+
+	test.beforeEach( async () => {
+		data = await fixtures.createFromTemplate( {
+			template: 'simple',
+			skipView: true,
+		} );
+	} );
+
+	test.afterEach( async () => {
+		if ( data?.test_id ) {
+			await cleanup( data.test_id );
+		}
+	} );
+
+	test( 'restricting access denies anonymous GETs but allows admin', async ( {
+		page,
+		request,
+	} ) => {
+		await enableDownloadUrl( page, data.form_id );
+		const url = await readDownloadUrl( page );
+
+		const baseline = await anonGet( url );
+		expect(
+			baseline.status,
+			'Baseline anonymous request should succeed when permissions are open'
+		).toBe( 200 );
+
+		// Flip permissions to "Logged-in only" via the persisted feed meta.
+		patchExportFeedMeta( data.form_id, { is_secured: '1' } );
+
+		// Anonymous request is now denied.
+		const anonAfter = await anonGet( url );
+		expect(
+			anonAfter.status,
+			'After enabling restriction, anonymous must not receive the export'
+		).not.toBe( 200 );
+
+		// Admin (the `request` fixture inherits the bootstrap login
+		// storage state) still gets the file.
+		const adminResponse = await fetchDownload( request, url );
+		expect(
+			adminResponse.status,
+			'Admin should still be able to download'
+		).toBe( 200 );
+		expect( adminResponse.body.length ).toBeGreaterThan( 512 );
+	} );
+} );


### PR DESCRIPTION
## Summary

- Adds 11 Playwright happy-path specs covering the Lite-side behavior: download URL lifecycle (enable, .xlsx default, .csv extension, regenerate/disable), admin configuration (disable field, sort order, logged-in restriction), data shaping (transpose, entry notes), and notification attachment (CSV + XLSX). With the existing `activation.spec.js` the suite is 14 specs.
- Adds the supporting infrastructure: a `tests/E2E/helpers/test-helpers.js` wrapper around `@gravitykit/e2e-bootstrap` with GravityExport-specific helpers, and a small `e2e-mail-capture` mu-plugin that short-circuits `wp_mail` and exposes the captured payloads + attachments over REST. Discovery doc and rationale live at `.claude/gravityexport-lite-happy-paths.md`.
- Out of scope (and documented in the discovery doc): per-field custom column labels (Pro-only UI), combined multi-form report (no Lite admin UI), URL-search filters (param syntax not ground-truthed).

## Test plan
- [ ] `npm run tests:e2e:setup` (only on a fresh clone — re-uses an existing `wp-env` instance otherwise)
- [ ] `npm run tests:e2e:run` — full suite green
- [ ] Spot-check `npx playwright test --config=tests/E2E/setup/playwright.config.js tests/E2E/tests/notifications --repeat-each 5` to confirm the notification specs are stable
- [ ] CircleCI `run_e2e_tests` job green on this branch

💾 [Build file](https://www.dropbox.com/scl/fi/u84spbzimrmuvgyak1q2z/gf-entries-in-excel-2.6.0-dfd260a.zip?rlkey=87l33nfay0uz8kwx6junhji4q&dl=1) (dfd260a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a 14-spec E2E happy-path suite for GravityExport Lite: download URLs (XLSX/CSV), URL regen/disable, CSV extension handling, transpose mode, field enable/disable and ordering, entry notes, notification attachments (CSV/XLSX), and permission gating.

* **Chores**
  * Added mail-capture test support, Playwright/wp-env setup improvements, host mail-capture mapping, and more robust CI cleanup.

* **Documentation**
  * Added a detailed "Happy Paths" blueprint describing Lite behaviors and prioritized E2E coverage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GravityKit/GravityExport-Lite/pull/239)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->