### PR TITLE
Add post-build smoke E2E against built .zip artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,55 @@ jobs:
               echo "Skipping translation pipeline."
             fi
       - run:
+          name: Collect build artifacts
+          command: |
+            mkdir -p .release
+            cp gf-entries-in-excel-*.zip .release/ 2>/dev/null || true
+      - store_artifacts:
+          path: .release
+          destination: release
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - plugin/.release
+            - plugin/gf-entries-in-excel-*.zip
+
+  run_post_build_smoke:
+    <<: *default_job_config
+    working_directory: /home/circleci/plugin
+    machine:
+      image: default
+      docker_layer_caching: true
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Post-build smoke
+          # Unzips .release/*.zip, restores dev deps via gktools' Docker composer,
+          # boots wp-env with retry, runs `playwright test --grep=@smoke` against
+          # the built artifact. See @gravitykit/e2e-bootstrap README for details.
+          command: |
+            npx @gravitykit/e2e-bootstrap smoke \
+              --composer-cmd "npx @gravitykit/gktools composer install"
+      - store_artifacts:
+          path: tests/E2E/results
+      - store_artifacts:
+          path: tests/E2E/report
+      - store_test_results:
+          path: tests/E2E/results/junit.xml
+
+  publish_release:
+    <<: *default_job_config
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Configure git
+          command: |
+            git config user.email "support@gravitykit.com"
+            git config user.name "GravityKit - CI"
+      - run:
           name: Create GitHub release
           command: npx @gravitykit/gktools release
       - run:
@@ -127,14 +176,6 @@ jobs:
             if ! git log -1 --pretty=%B | grep -iq "\[skip notify\]"; then
               npx @gravitykit/gktools announce
             fi
-      - run:
-          name: Collect build artifacts
-          command: |
-            mkdir -p .release
-            cp gf-entries-in-excel-*.zip .release/ 2>/dev/null || true
-      - store_artifacts:
-          path: .release
-          destination: release
 
 workflows:
   version: 2
@@ -148,3 +189,11 @@ workflows:
           <<: *context
           requires:
             - prepare
+      - run_post_build_smoke:
+          <<: *context
+          requires:
+            - build_package_release
+      - publish_release:
+          <<: *context
+          requires:
+            - run_post_build_smoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           name: Collect build artifacts
           command: |
             mkdir -p .release
-            cp gf-entries-in-excel-*.zip .release/ 2>/dev/null || true
+            cp gf-entries-in-excel-*.zip .release/
       - store_artifacts:
           path: .release
           destination: release
@@ -134,7 +134,6 @@ jobs:
 
   run_post_build_smoke:
     <<: *default_job_config
-    working_directory: /home/circleci/plugin
     machine:
       image: default
       docker_layer_caching: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-2.0",
       "devDependencies": {
-        "@gravitykit/e2e-bootstrap": "^1.0.0",
+        "@gravitykit/e2e-bootstrap": "^1.1.0",
         "@playwright/test": "1.56.1",
         "@wordpress/env": "^10.0.0",
         "grunt": "^1.5.3",
@@ -18,14 +18,17 @@
       }
     },
     "node_modules/@gravitykit/e2e-bootstrap": {
-      "version": "1.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@gravitykit/e2e-bootstrap/1.0.0/4f5bef34f2b159367dbc43bbb46e02e1de39f579",
-      "integrity": "sha512-fSsX3g5iLy3p6UuuV8qsihqlqdq6LsxkcmQGRC90xd3s85Ve1GwSkC766XmvWIGHtTTZBP0WwJmgykrLJTSAfw==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@gravitykit/e2e-bootstrap/1.1.0/d14bcc5d6e2b8e4a37e0ae43497895a41710473c",
+      "integrity": "sha512-TCUlswVxxcOI7ItXeO/3eXZyJhLzxZk9hYuekZW/GdU+Arf1GPbn6Pj1DGbGU9Cgg7rmDf9Qrl9Xas6nf7FNWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@gravitykit/e2e-fixtures": "^1.2.0",
         "dotenv": "^16.4.5"
+      },
+      "bin": {
+        "e2e-bootstrap": "bin/cli.js"
       },
       "peerDependencies": {
         "@playwright/test": ">=1.56.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "tests:e2e:run": "playwright test --config=tests/E2E/setup/playwright.config.js"
   },
   "devDependencies": {
-    "@gravitykit/e2e-bootstrap": "^1.0.0",
+    "@gravitykit/e2e-bootstrap": "^1.1.0",
     "@playwright/test": "1.56.1",
     "@wordpress/env": "^10.0.0",
     "grunt": "^1.5.3",

--- a/tests/E2E/tests/activation.spec.js
+++ b/tests/E2E/tests/activation.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-test.describe('GravityExport Lite — Activation Smoke Test', () => {
+test.describe('GravityExport Lite — Activation Smoke Test @smoke', () => {
 
 	test('Plugin activates without fatal PHP errors', async ({ page } ) => {
 		await page.goto('/wp-admin/plugins.php');


### PR DESCRIPTION
## Summary
- Runs the `@smoke`-tagged activation suite against the **packaged plugin zip** in CI, gated between `build_package_release` and the new `publish_release` job — so a failed smoke now blocks the GitHub release + announcement.
- Mirrors the canonical pipeline shape established in the sister plugin GravityExport (PR #167) and originally GravityImport (PR #506).

## Pipeline shape (workflow shape A)
`prepare` (single job) → `run_e2e_tests` (pre-build) / `build_package_release` → `run_post_build_smoke` → `publish_release`

`prepare` already installs deps AND writes `.env`, so the linear ancestor chain inherits the environment without conflict. No workspace surgery needed.

## Changes
- `.circleci/config.yml`
  - `build_package_release`: moved `Collect build artifacts` up, then `persist_to_workspace` exports both `plugin/.release` and the `plugin/gf-entries-in-excel-*.zip` glob (the latter is required because `gktools release` greps cwd, not `.release/`).
  - Added `run_post_build_smoke` job: machine + DLC, attaches workspace, invokes `npx @gravitykit/e2e-bootstrap smoke --composer-cmd "npx @gravitykit/gktools composer install"` (Composer must run inside gktools' PHP 7.4 Docker), uploads Playwright results/report + JUnit.
  - Extracted `Create GitHub release` + `Announce build` into a new `publish_release` job that `requires: run_post_build_smoke`.
  - Workflow wires `run_post_build_smoke` → `build_package_release`, `publish_release` → `run_post_build_smoke`.
- `tests/E2E/tests/activation.spec.js` — appended `@smoke` to the `describe` title so the bootstrap CLI grep picks it up.
- `package.json` + `package-lock.json` — bumped `@gravitykit/e2e-bootstrap` from `^1.0.0` to `^1.1.0` (smoke subcommand). Lock diff scoped to this dep only.

## Test plan
- [ ] CircleCI workflow `test_and_release` runs on this branch; verify `run_post_build_smoke` job appears and consumes the built artifact (logs should show unzip of `gf-entries-in-excel-*.zip`, composer install via gktools Docker, wp-env boot, `playwright test --grep=@smoke`).
- [ ] On smoke pass, `publish_release` runs; on smoke fail, `publish_release` is blocked.
- [ ] Smoke runs only the `@smoke`-tagged describe (the three activation tests), not the full E2E suite.
- [ ] `tests/E2E/results/junit.xml` is uploaded as test results.

## Notes
- Existing pre-build `run_e2e_tests` is untouched and continues to run the full suite against the source tree.
- `playwright.config.js` already uses a single chromium project (no `dependencies: ['chromium']` split), so no Playwright #22408 grep-bypass fix needed.
- `wp-env.config.js` already hard-codes `pluginPath: '../../..'` (no `BUILT_PLUGIN_PATH` conditional); the bootstrap CLI rewrites this internally when unzipping the built artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Smoke testing now runs automatically after builds to validate packaged content
  * Test organization improved with dedicated smoke test marker for activation smoke tests

* **Chores**
  * CI/CD release pipeline enhanced: build artifacts are collected and persisted during the build phase
  * Added a dedicated post-build verification stage that runs against the packaged artifact before release
  * Release step now proceeds directly to creating the GitHub release (artifact collection moved earlier)
  * Testing framework dev dependency updated to ^1.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GravityKit/GravityExport-Lite/pull/241)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/q7mmrssx4mh8te7s1x0tx/gf-entries-in-excel-2.6.0-154e40c.zip?rlkey=15ip4uv5qp18wkujanpnu76gd&dl=1) (154e40c).