### PR TITLE
Show the global settings page to roles with export access

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -259,6 +259,7 @@ You can hide a row by adding a hook. Checkout this example:
 = TBD =
 
 * Fixed: Sites running PHP 8.4 or newer logged repeated "deprecated" warnings on every page.
+* Fixed: The global settings page was hidden for administrators when the Members plugin managed capabilities. The page now requires the "Export Entries" capability, which can be granted per role.
 
 = 2.7.0 on August 6, 2026 =
 

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -84,6 +84,18 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 	protected $_capabilities_form_settings = 'gravityforms_export_entries';
 
 	/**
+	 * @since $ver$
+	 * @var string Global settings permissions.
+	 */
+	protected $_capabilities_settings_page = 'gravityforms_export_entries';
+
+	/**
+	 * @since $ver$
+	 * @var string Uninstall permissions.
+	 */
+	protected $_capabilities_uninstall = 'gravityforms_uninstall';
+
+	/**
 	 * @since 2.0.0
 	 * @var string Relative path to file from plugins directory.
 	 */


### PR DESCRIPTION
Fixes [GEXPLIT-21](https://linear.app/gravitykit/issue/GEXPLIT-21/global-settings-page-hidden-when-the-members-plugin-manages).

## Problem

With the [Members](https://wordpress.org/plugins/members/) plugin active, the global settings page (Forms → Settings → GravityExport Lite) disappeared for administrators. Since the page is the only way to turn on **Multiple Columns → "Split multi-fields (name, address) into multiple columns"**, name and address fields kept exporting as a single column with no way to change it. Reported by a customer whose name fields would not split while the same versions split fine elsewhere.

## Cause

`$_capabilities_settings_page` and `$_capabilities_uninstall` were never declared, so they stayed at `GFAddOn`'s empty-array default. `GFCommon::current_user_can_any( [] )` skips the (empty) capability loop and falls through to `gform_full_access` alone (`common.php:2853-2861`), and that capability is not a normal role capability — `GFForms::user_has_cap()` grants it on the fly (`gravityforms.php:1553-1586`):

- **No Members plugin** → every administrator gets it. This is why it works on most sites, and why User Role Editor is unaffected: `has_members_plugin()` only looks for Members.
- **Members active** → an administrator gets it *only when they hold no Gravity Forms capability at all*. Grant the role any Gravity Forms capability and it is withheld.

So `current_user_can_any()` returned false and `plugin_settings_init()` was never called (`class-gf-addon.php:486-490`), leaving no tab and no page.

The paid add-on already declares the settings-page capability; Lite never got it.

## Fix

Declare both capabilities, matching the feed settings tab:

```php
protected $_capabilities_settings_page = 'gravityforms_export_entries';
protected $_capabilities_uninstall     = 'gravityforms_uninstall';
```

Both names are real Gravity Forms capabilities (`GFCommon::all_caps()`). A side benefit: `GFAddOn::get_members_caps()` only advertises capabilities that are non-empty strings, so the add-on now appears in the role manager's Gravity Forms group as "Add-On Settings" and "Uninstall" and can be granted per role. Previously it contributed nothing there.

## Testing

Local site: Gravity Forms 2.10.0 + GravityExport Lite, Members active, Gravity Forms capabilities granted to the `administrator` role (both conditions are required — a fresh Members install with no Gravity Forms capabilities granted still gets `gform_full_access`, which is why this looks intermittent).

Counting the settings tab link on `admin.php?page=gf_settings`:

| | `gform_full_access` | tab link | settings page |
|---|---|---|---|
| before | false | 0 | unreachable |
| after | false | 1 | renders, split checkbox present |

`get_members_caps()` after the change returns `{"gravityforms_export_entries":"Add-On Settings","gravityforms_uninstall":"Uninstall"}`.

Worth a second pair of eyes on whether requiring `gravityforms_uninstall` for the uninstall section is right, or whether that should stay as it was.

## Workaround for affected users

Force the split on without reaching the settings page:

```php
add_filter( 'gfexcel_field_separated', '__return_true' );
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability controls for the Gravity Forms settings and uninstall pages.
  * Administrators can now manage access to these pages by role when capability management is enabled.

* **Documentation**
  * Updated the changelog to document the new “Export Entries” requirement for global settings access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/hexcqoibbfkl4imzv8vro/gf-entries-in-excel-2.7.0-f2cc59c.zip?rlkey=e7gzuderkrb6tgvja8ft451rl&dl=1) (f2cc59c).