### PR TITLE
Release 2.7.1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -26,6 +26,7 @@ phpstan-stubs
 /.git
 /.idea
 /tests
+/bin
 /vendor
 /vendor_prefixed
 /src

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,7 @@ phpstan-stubs export-ignore
 /.github export-ignore
 /.idea export-ignore
 /assets export-ignore
+/bin export-ignore
 /src export-ignore
 /tests export-ignore
 .env.sample export-ignore

--- a/bin/fix-vendored-php-deprecations.php
+++ b/bin/fix-vendored-php-deprecations.php
@@ -18,7 +18,7 @@
  * generated. Fails the build if a target signature no longer matches, so a dependency bump cannot silently
  * ship unpatched.
  *
- * @since TBD
+ * @since 2.7.1
  */
 
 $vendor_dir = __DIR__ . '/../build/vendor_prefixed';

--- a/bin/fix-vendored-php-deprecations.php
+++ b/bin/fix-vendored-php-deprecations.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Rewrites PHP deprecations in the Strauss-prefixed vendor tree.
+ *
+ * Strauss rewrites these files under our `GFExcel\Vendor\` prefix, so any deprecation they emit reads as our
+ * code in a customer's error log. Both dependencies below are pinned to versions that predate the deprecation
+ * and have no fixed release we can move to without an API break, so the shipped copy is patched instead.
+ *
+ * - league/container 3.4.1 writes `Type $param = null`, implicitly nullable, which PHP 8.4 deprecates at
+ *   compile time — so it fires on every request that boots the container, not only when the method is called.
+ *   3.4.1 is the last 3.x release. Moving to 4.x drops the third `$shared` argument from `Container::add()`,
+ *   which `AbstractServiceProvider::addAction()` and `AddOnProvider::addAutoStart()` both pass, so it needs a
+ *   compatibility shim and a review of every add-on built against the current service-provider API.
+ * - phpspreadsheet 1.19.0 uses `${var}` string interpolation, deprecated in PHP 8.2. It reaches customers
+ *   through the `PhpOffice\PhpSpreadsheet\*` compatibility aliases registered in gfexcel.php.
+ *
+ * Runs during `composer build`, after Strauss has written build/vendor_prefixed/ and before the autoloader is
+ * generated. Fails the build if a target signature no longer matches, so a dependency bump cannot silently
+ * ship unpatched.
+ *
+ * @since TBD
+ */
+
+$vendor_dir = __DIR__ . '/../build/vendor_prefixed';
+
+$replacements = [
+	'league/container/src/Container.php'                            => [
+		[
+			"        DefinitionAggregateInterface      \$definitions = null,\n"
+			. "        ServiceProviderAggregateInterface \$providers = null,\n"
+			. "        InflectorAggregateInterface       \$inflectors = null\n",
+			"        ?DefinitionAggregateInterface      \$definitions = null,\n"
+			. "        ?ServiceProviderAggregateInterface \$providers = null,\n"
+			. "        ?InflectorAggregateInterface       \$inflectors = null\n",
+		],
+		[
+			'public function add(string $id, $concrete = null, bool $shared = null)',
+			'public function add(string $id, $concrete = null, ?bool $shared = null)',
+		],
+		[
+			'public function inflector(string $type, callable $callback = null)',
+			'public function inflector(string $type, ?callable $callback = null)',
+		],
+	],
+	'league/container/src/Inflector/Inflector.php'                  => [
+		[
+			'public function __construct(string $type, callable $callback = null)',
+			'public function __construct(string $type, ?callable $callback = null)',
+		],
+	],
+	'league/container/src/Inflector/InflectorAggregate.php'         => [
+		[
+			'public function add(string $type, callable $callback = null)',
+			'public function add(string $type, ?callable $callback = null)',
+		],
+	],
+	'league/container/src/Inflector/InflectorAggregateInterface.php' => [
+		[
+			'public function add(string $type, callable $callback = null)',
+			'public function add(string $type, ?callable $callback = null)',
+		],
+	],
+	'phpoffice/phpspreadsheet/src/PhpSpreadsheet/Reader/Xlsx.php'   => [
+		[
+			'"xl/_rels/${workbookBasename}.rels"',
+			'"xl/_rels/{$workbookBasename}.rels"',
+		],
+	],
+];
+
+$errors  = [];
+$patched = 0;
+
+foreach ( $replacements as $relative_path => $pairs ) {
+	$file = $vendor_dir . '/' . $relative_path;
+
+	if ( ! is_file( $file ) ) {
+		$errors[] = sprintf( '%s: file not found.', $relative_path );
+
+		continue;
+	}
+
+	$contents = file_get_contents( $file );
+	$original = $contents;
+
+	foreach ( $pairs as list( $search, $replace ) ) {
+		$occurrences = substr_count( $contents, $search );
+
+		// Re-running against an already-patched tree is a no-op, not a failure.
+		if ( 0 === $occurrences && 1 === substr_count( $contents, $replace ) ) {
+			continue;
+		}
+
+		if ( 1 !== $occurrences ) {
+			$errors[] = sprintf(
+				'%s: expected 1 occurrence of "%s", found %d.',
+				$relative_path,
+				trim( strtok( $search, "\n" ) ),
+				$occurrences
+			);
+
+			continue;
+		}
+
+		$contents = str_replace( $search, $replace, $contents );
+		$patched ++;
+	}
+
+	if ( $contents !== $original && false === file_put_contents( $file, $contents ) ) {
+		$errors[] = sprintf( '%s: could not be written.', $relative_path );
+	}
+}
+
+if ( $errors ) {
+	fwrite( STDERR, "Failed to patch the vendored dependencies for PHP 8.2+:\n - " . implode( "\n - ", $errors ) . "\n" );
+
+	exit( 1 );
+}
+
+printf( "Patched %d deprecated declarations in vendor_prefixed.\n", $patched );

--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,7 @@
             "composer remove gravityforms/gravityforms gravityforms/gravitysurvey --no-update --dev --working-dir=build",
             "composer require gravitykit/gravityexport-lite-src:@dev --update-no-dev --working-dir=build --no-scripts --ignore-platform-reqs",
             "cd build && ./strauss.phar",
+            "php bin/fix-vendored-php-deprecations.php",
             "composer dump-autoload -o --working-dir=build"
         ],
         "linter": "vendor/bin/phplint --no-cache",

--- a/gfexcel.php
+++ b/gfexcel.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     GravityExport Lite
- * Version:         2.7.0
+ * Version:         2.7.1
  * Plugin URI:      https://gfexcel.com
  * Description:     Export all Gravity Forms entries to Excel (.xlsx) or CSV via a secret shareable URL.
  * Author:          GravityKit
@@ -28,7 +28,7 @@ if ( ! defined( 'GFEXCEL_PLUGIN_FILE' ) ) {
 }
 
 if ( ! defined( 'GFEXCEL_PLUGIN_VERSION' ) ) {
-	define( 'GFEXCEL_PLUGIN_VERSION', '2.7.0' );
+	define( 'GFEXCEL_PLUGIN_VERSION', '2.7.1' );
 }
 
 if ( ! defined( 'GFEXCEL_MIN_PHP_VERSION' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -259,6 +259,7 @@ You can hide a row by adding a hook. Checkout this example:
 = TBD =
 
 * Fixed: Sites running PHP 8.4 or newer logged repeated "deprecated" warnings on every page.
+* Fixed: The global settings page was hidden for administrators when the Members plugin managed capabilities. The page now requires the "Export Entries" capability, which can be granted per role.
 
 = 2.7.0 on August 6, 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -256,6 +256,10 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
+= TBD =
+
+* Fixed: Sites running PHP 8.4 or newer logged repeated "deprecated" warnings on every page.
+
 = 2.7.0 on August 6, 2026 =
 
 * Added: The single-entry export attached to a notification is now saved to a unique temporary folder, so simultaneous submissions can no longer overwrite each other's attachment.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Gravity Forms, GravityForms, Excel, Export, Entries
 Requires at least: 4.0
 Requires PHP: 7.2
 Tested up to: 7.0.3
-Stable tag: 2.7.0
+Stable tag: 2.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -256,7 +256,7 @@ You can hide a row by adding a hook. Checkout this example:
 
 == Changelog ==
 
-= TBD =
+= 2.7.1 on August 14, 2026 =
 
 * Fixed: Sites running PHP 8.4 or newer logged repeated "deprecated" warnings on every page.
 * Fixed: The global settings page was hidden for administrators when the Members plugin managed capabilities. The page now requires the "Export Entries" capability, which can be granted per role.

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -84,6 +84,18 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 	protected $_capabilities_form_settings = 'gravityforms_export_entries';
 
 	/**
+	 * @since $ver$
+	 * @var string Global settings permissions.
+	 */
+	protected $_capabilities_settings_page = 'gravityforms_export_entries';
+
+	/**
+	 * @since $ver$
+	 * @var string Uninstall permissions.
+	 */
+	protected $_capabilities_uninstall = 'gravityforms_uninstall';
+
+	/**
 	 * @since 2.0.0
 	 * @var string Relative path to file from plugins directory.
 	 */

--- a/src/Addon/GravityExportAddon.php
+++ b/src/Addon/GravityExportAddon.php
@@ -84,13 +84,13 @@ final class GravityExportAddon extends \GFFeedAddOn implements AddonInterface, A
 	protected $_capabilities_form_settings = 'gravityforms_export_entries';
 
 	/**
-	 * @since $ver$
+	 * @since 2.7.1
 	 * @var string Global settings permissions.
 	 */
 	protected $_capabilities_settings_page = 'gravityforms_export_entries';
 
 	/**
-	 * @since $ver$
+	 * @since 2.7.1
 	 * @var string Uninstall permissions.
 	 */
 	protected $_capabilities_uninstall = 'gravityforms_uninstall';

--- a/src/Plugin/BasePlugin.php
+++ b/src/Plugin/BasePlugin.php
@@ -37,7 +37,7 @@ abstract class BasePlugin
      * @param ContainerInterface $container The service container.
      * @param string|null $assets_dir The assets directory.
      */
-    public function __construct(ContainerInterface $container, string $assets_dir = null)
+    public function __construct(ContainerInterface $container, ?string $assets_dir = null)
     {
         $this->container = $container;
         $this->assets_dir = $assets_dir;

--- a/tests/ImplicitNullableTest.php
+++ b/tests/ImplicitNullableTest.php
@@ -1,0 +1,344 @@
+<?php
+
+namespace GFExcel\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Guards the plugin source against PHP 8.4's implicitly-nullable-parameter deprecation.
+ *
+ * A parameter written as `Type $param = null` is implicitly nullable, which PHP 8.4 deprecates at compile
+ * time — so the notice fires on every request that loads the class, not only when the method is called.
+ * Tokenizing rather than reflecting keeps this runnable on every supported PHP version.
+ *
+ * @since TBD
+ *
+ * @see https://linear.app/gravitykit/issue/GEXPLIT-20
+ */
+class ImplicitNullableTest extends TestCase
+{
+    /**
+     * Asserts no source file declares an implicitly nullable parameter.
+     * @since TBD
+     */
+    public function testSourceHasNoImplicitlyNullableParameters(): void
+    {
+        $offenders = [];
+
+        foreach ($this->shippedSourceFiles() as $file) {
+            $offenders = array_merge($offenders, $this->findImplicitlyNullableParameters($file));
+        }
+
+        sort($offenders);
+
+        $this->assertSame([], $offenders, sprintf(
+            "Implicitly nullable parameters are deprecated as of PHP 8.4; declare them as `?Type \$param = null`:\n- %s",
+            implode("\n- ", $offenders)
+        ));
+    }
+
+    /**
+     * Returns every PHP file the plugin ships from its own codebase.
+     *
+     * `gfexcel.php` and `uninstall.php` sit in the plugin root and ship too, so scanning `src/` alone would
+     * leave them unguarded.
+     *
+     * @since TBD
+     * @return string[] Absolute paths.
+     */
+    private function shippedSourceFiles(): array
+    {
+        $root = dirname(__DIR__);
+        $files = glob($root . '/*.php') ?: [];
+
+        $source = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . '/src'));
+
+        foreach ($source as $file) {
+            if ($file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Asserts the build still patches the vendored dependencies.
+     *
+     * The patcher only runs during `composer build`, so without this the step could be dropped and every
+     * test would stay green while the shipped plugin went back to emitting the notices.
+     *
+     * @since TBD
+     */
+    public function testBuildPatchesVendoredDeprecations(): void
+    {
+        $root = dirname(__DIR__);
+        $composer = json_decode((string) file_get_contents($root . '/composer.json'), true);
+        $build = $composer['scripts']['build'] ?? [];
+
+        $this->assertContains(
+            'php bin/fix-vendored-php-deprecations.php',
+            $build,
+            'The `build` script must run the vendored-deprecation patcher, or the shipped plugin will emit '
+            . 'PHP deprecation notices under our own namespace prefix.'
+        );
+
+        $this->assertFileExists($root . '/bin/fix-vendored-php-deprecations.php');
+
+        // The patcher must run after Strauss writes vendor_prefixed/, otherwise it has nothing to patch.
+        $strauss = array_search('cd build && ./strauss.phar', $build, true);
+        $patcher = array_search('php bin/fix-vendored-php-deprecations.php', $build, true);
+
+        $this->assertIsInt($strauss, 'The `build` script must still run Strauss.');
+        $this->assertGreaterThan($strauss, $patcher, 'The patcher must run after Strauss.');
+    }
+
+    /**
+     * Returns `file:line $param` for every implicitly nullable parameter in a file.
+     * @since TBD
+     * @param string $path Absolute path to the PHP file.
+     * @return string[] The offending parameters.
+     */
+    private function findImplicitlyNullableParameters(string $path): array
+    {
+        $offenders = [];
+        $tokens = array_values(array_filter(
+            token_get_all((string) file_get_contents($path)),
+            static function ($token): bool {
+                return !is_array($token) || !in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true);
+            }
+        ));
+        $count = count($tokens);
+
+        // T_FN (arrow functions) only exists on PHP 7.4+.
+        $function_tokens = defined('T_FN') ? [T_FUNCTION, constant('T_FN')] : [T_FUNCTION];
+
+        for ($i = 0; $i < $count; $i++) {
+            if (!is_array($tokens[$i]) || !in_array($tokens[$i][0], $function_tokens, true)) {
+                continue;
+            }
+
+            // `fn` is a valid method name, and PHP still tokenizes it as T_FN there — skip the name, not
+            // the declaration, or the parameter list gets scanned twice.
+            $previous = $tokens[$i - 1] ?? null;
+
+            if (is_array($previous) && $previous[0] === T_FUNCTION) {
+                continue;
+            }
+
+            $open = $this->findNext($tokens, $i + 1, '(');
+
+            if ($open === null) {
+                continue;
+            }
+
+            foreach ($this->splitParameters($tokens, $open) as $parameter) {
+                $offender = $this->describeIfImplicitlyNullable($parameter, basename($path));
+
+                if ($offender !== null) {
+                    $offenders[] = $offender;
+                }
+            }
+        }
+
+        return $offenders;
+    }
+
+    /**
+     * Returns the index of the next occurrence of a literal token, or null.
+     * @since TBD
+     * @param array $tokens The token list.
+     * @param int $from The index to start at.
+     * @param string $needle The literal token to find.
+     * @return int|null The index, or null when not found.
+     */
+    private function findNext(array $tokens, int $from, string $needle): ?int
+    {
+        for ($i = $from; $i < count($tokens); $i++) {
+            if ($tokens[$i] === $needle) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Splits a parameter list into one token list per parameter.
+     * @since TBD
+     * @param array $tokens The token list.
+     * @param int $open The index of the parameter list's opening parenthesis.
+     * @return array[] One token list per declared parameter.
+     */
+    private function splitParameters(array $tokens, int $open): array
+    {
+        $parameters = [];
+        $current = [];
+        $depth = 0;
+
+        for ($i = $open; $i < count($tokens); $i++) {
+            $token = $tokens[$i];
+
+            // An attribute opens with `#[` and closes with `]`. Skip it whole: its arguments are not part of
+            // the parameter, and its brackets would otherwise unbalance the depth count.
+            if (is_array($token) && defined('T_ATTRIBUTE') && $token[0] === constant('T_ATTRIBUTE')) {
+                $i = $this->skipAttribute($tokens, $i);
+
+                continue;
+            }
+
+            if (in_array($token, ['(', '[', '{'], true)) {
+                $depth++;
+
+                if ($depth === 1) {
+                    continue;
+                }
+            }
+
+            if (in_array($token, [')', ']', '}'], true)) {
+                $depth--;
+
+                if ($depth === 0) {
+                    if ($current) {
+                        $parameters[] = $current;
+                    }
+
+                    break;
+                }
+            }
+
+            if ($depth === 1 && $token === ',') {
+                $parameters[] = $current;
+                $current = [];
+
+                continue;
+            }
+
+            $current[] = $token;
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * Returns the index of the `]` closing an attribute that opens at `$start`.
+     * @since TBD
+     * @param array $tokens The token list.
+     * @param int $start The index of the T_ATTRIBUTE token.
+     * @return int The index of the closing bracket.
+     */
+    private function skipAttribute(array $tokens, int $start): int
+    {
+        $depth = 1;
+
+        for ($i = $start + 1; $i < count($tokens); $i++) {
+            if (in_array($tokens[$i], ['(', '[', '{'], true)) {
+                $depth++;
+
+                continue;
+            }
+
+            if (in_array($tokens[$i], [')', ']', '}'], true)) {
+                $depth--;
+
+                if ($depth === 0) {
+                    return $i;
+                }
+            }
+        }
+
+        return $start;
+    }
+
+    /**
+     * Returns `file:line $param` when the parameter is implicitly nullable, otherwise null.
+     * @since TBD
+     * @param array $parameter The parameter's tokens.
+     * @param string $file The file's basename, for the message.
+     * @return string|null The description, or null when the parameter is fine.
+     */
+    private function describeIfImplicitlyNullable(array $parameter, string $file): ?string
+    {
+        // Promoted properties carry visibility/readonly keywords before the type; they are not part of it.
+        $modifiers = ['public', 'protected', 'private', 'readonly'];
+
+        $type_tokens = [];
+        $variable = null;
+        $line = 0;
+        $default = [];
+        $seen_equals = false;
+
+        foreach ($parameter as $token) {
+            if ($token === '=') {
+                $seen_equals = true;
+
+                continue;
+            }
+
+            if ($seen_equals) {
+                $default[] = $token;
+
+                continue;
+            }
+
+            if (is_array($token) && $token[0] === T_VARIABLE) {
+                $variable = $token[1];
+                $line = $token[2];
+
+                continue;
+            }
+
+            if ($variable !== null) {
+                continue;
+            }
+
+            if (is_array($token) && in_array(strtolower($token[1]), $modifiers, true)) {
+                continue;
+            }
+
+            $type_tokens[] = $token;
+        }
+
+        if ($variable === null || !$default) {
+            return null;
+        }
+
+        $type = strtolower($this->stringify($type_tokens));
+
+        // `&` and `...` sit between the type and the variable; only a trailing one is a marker, not a type.
+        $type = rtrim($type, '&.');
+
+        if ($type === '' || strpos($type, '?') === 0) {
+            return null;
+        }
+
+        // A `null` or `mixed` arm already makes the type nullable.
+        $arms = explode('|', $type);
+
+        if (in_array('null', $arms, true) || in_array('mixed', $arms, true)) {
+            return null;
+        }
+
+        // `= (null)` is still an implicitly nullable default.
+        if (trim($this->stringify($default), '() ') !== 'null') {
+            return null;
+        }
+
+        return sprintf('%s:%d %s', $file, $line, $variable);
+    }
+
+    /**
+     * Flattens a token list back into its source text.
+     * @since TBD
+     * @param array $tokens The token list.
+     * @return string The source text.
+     */
+    private function stringify(array $tokens): string
+    {
+        return strtolower(implode('', array_map(static function ($token) {
+            return is_array($token) ? $token[1] : $token;
+        }, $tokens)));
+    }
+}

--- a/tests/ImplicitNullableTest.php
+++ b/tests/ImplicitNullableTest.php
@@ -13,7 +13,7 @@ use RecursiveIteratorIterator;
  * time — so the notice fires on every request that loads the class, not only when the method is called.
  * Tokenizing rather than reflecting keeps this runnable on every supported PHP version.
  *
- * @since TBD
+ * @since 2.7.1
  *
  * @see https://linear.app/gravitykit/issue/GEXPLIT-20
  */
@@ -21,7 +21,7 @@ class ImplicitNullableTest extends TestCase
 {
     /**
      * Asserts no source file declares an implicitly nullable parameter.
-     * @since TBD
+     * @since 2.7.1
      */
     public function testSourceHasNoImplicitlyNullableParameters(): void
     {
@@ -45,7 +45,7 @@ class ImplicitNullableTest extends TestCase
      * `gfexcel.php` and `uninstall.php` sit in the plugin root and ship too, so scanning `src/` alone would
      * leave them unguarded.
      *
-     * @since TBD
+     * @since 2.7.1
      * @return string[] Absolute paths.
      */
     private function shippedSourceFiles(): array
@@ -70,7 +70,7 @@ class ImplicitNullableTest extends TestCase
      * The patcher only runs during `composer build`, so without this the step could be dropped and every
      * test would stay green while the shipped plugin went back to emitting the notices.
      *
-     * @since TBD
+     * @since 2.7.1
      */
     public function testBuildPatchesVendoredDeprecations(): void
     {
@@ -97,7 +97,7 @@ class ImplicitNullableTest extends TestCase
 
     /**
      * Returns `file:line $param` for every implicitly nullable parameter in a file.
-     * @since TBD
+     * @since 2.7.1
      * @param string $path Absolute path to the PHP file.
      * @return string[] The offending parameters.
      */
@@ -148,7 +148,7 @@ class ImplicitNullableTest extends TestCase
 
     /**
      * Returns the index of the next occurrence of a literal token, or null.
-     * @since TBD
+     * @since 2.7.1
      * @param array $tokens The token list.
      * @param int $from The index to start at.
      * @param string $needle The literal token to find.
@@ -167,7 +167,7 @@ class ImplicitNullableTest extends TestCase
 
     /**
      * Splits a parameter list into one token list per parameter.
-     * @since TBD
+     * @since 2.7.1
      * @param array $tokens The token list.
      * @param int $open The index of the parameter list's opening parenthesis.
      * @return array[] One token list per declared parameter.
@@ -224,7 +224,7 @@ class ImplicitNullableTest extends TestCase
 
     /**
      * Returns the index of the `]` closing an attribute that opens at `$start`.
-     * @since TBD
+     * @since 2.7.1
      * @param array $tokens The token list.
      * @param int $start The index of the T_ATTRIBUTE token.
      * @return int The index of the closing bracket.
@@ -254,7 +254,7 @@ class ImplicitNullableTest extends TestCase
 
     /**
      * Returns `file:line $param` when the parameter is implicitly nullable, otherwise null.
-     * @since TBD
+     * @since 2.7.1
      * @param array $parameter The parameter's tokens.
      * @param string $file The file's basename, for the message.
      * @return string|null The description, or null when the parameter is fine.
@@ -331,7 +331,7 @@ class ImplicitNullableTest extends TestCase
 
     /**
      * Flattens a token list back into its source text.
-     * @since TBD
+     * @since 2.7.1
      * @param array $tokens The token list.
      * @return string The source text.
      */


### PR DESCRIPTION
Release 2.7.1.

## Changelog

* Fixed: Sites running PHP 8.4 or newer logged repeated "deprecated" warnings on every page.
* Fixed: The global settings page was hidden for administrators when the Members plugin managed capabilities. The page now requires the "Export Entries" capability, which can be granted per role.

## Commits since 2.7.0

- 352f13e Stop the bundled dependencies from emitting PHP deprecation notices
- 3f84042 Show the global settings page to roles with export access (#244)
- b63e1db Bump version to 2.7.1 & update changelog

Merging this runs the release job, which tags `v2.7.1`, publishes the GitHub release and merges `main` back into `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved repeated PHP 8.4+ deprecation warnings.
  * Restored administrator access to global settings when capability management is enabled.
  * Improved compatibility with newer PHP versions through updated nullable parameter handling.

* **Chores**
  * Updated the plugin version to 2.7.1.
  * Excluded build utilities from distribution archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

💾 [Build file](https://www.dropbox.com/scl/fi/ixqi9nfhg92pt6mauiyc7/gf-entries-in-excel-2.7.1-b63e1db.zip?rlkey=u7gjcyufmv89n4jgds4ognymj&dl=1) (b63e1db).